### PR TITLE
Feature/#26 회원가입 API

### DIFF
--- a/server/src/controllers/user.ts
+++ b/server/src/controllers/user.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express';
+
+import userService from 'services/user';
+
+import errorHandler from 'utils/error/error-handler';
+
+interface IReqBody {
+  id: string;
+  password: string;
+}
+
+export const signUp = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id, password } = req.body as IReqBody;
+
+    const { accessToken, refreshToken } = await userService.signUp(id, password);
+
+    res.cookie('_rt', refreshToken, { httpOnly: true });
+    res.status(201).json({ accessToken });
+  } catch (err) {
+    console.log(err);
+    const { statusCode, errorMessage } = errorHandler(err);
+    res.status(statusCode).json({ errorMessage });
+  }
+};

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -10,7 +10,7 @@ export interface UserAttribures {
   phone: string;
 }
 
-export type UserCreationAttributes = Optional<UserAttribures, 'id'>;
+export type UserCreationAttributes = Optional<UserAttribures, 'id' | 'phone'>;
 
 const HASHED_PASSWORD_LENGTH = 60;
 

--- a/server/src/repositories/user.ts
+++ b/server/src/repositories/user.ts
@@ -1,0 +1,34 @@
+import { db } from 'models';
+import { Model } from 'sequelize';
+
+import { UserAttribures, UserCreationAttributes } from 'models/user';
+
+import errorGenerator from 'utils/error/error-generator';
+
+export const checkUserExists = async (user_id: string): Promise<void> => {
+  const userCount = await db.User.count({
+    where: {
+      user_id,
+    },
+  });
+
+  if (userCount > 0) {
+    throw errorGenerator({
+      message: 'POST /api/user - account already exists',
+      code: 'auth/existing-user',
+    });
+  }
+};
+
+export const createUser = async (
+  user_id: string,
+  password: string,
+): Promise<Model<UserAttribures, UserCreationAttributes>> => {
+  const user = await db.User.create({
+    user_id,
+    password,
+    provider: 'local',
+  });
+
+  return user;
+};

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,8 +1,11 @@
 import { Router } from 'express';
+
 import auth from './auth';
+import user from './user';
 
 const router = Router();
 
 router.use('/auth', auth);
+router.use('/user', user);
 
 export default router;

--- a/server/src/routes/user/index.ts
+++ b/server/src/routes/user/index.ts
@@ -1,10 +1,10 @@
 import { Router } from 'express';
 
-import { signIn } from 'controllers/auth';
+import { signUp } from 'controllers/user';
 import { authValidation } from 'validation/auth';
 
 const router = Router();
 
-router.post('/', authValidation, signIn);
+router.post('/', authValidation, signUp);
 
 export default router;

--- a/server/src/services/user.ts
+++ b/server/src/services/user.ts
@@ -1,0 +1,26 @@
+import { checkUserExists, createUser } from 'repositories/user';
+
+import { createToken } from 'utils/jwt';
+import { hashPassword } from 'utils/crypto';
+
+interface IToken {
+  accessToken: string;
+  refreshToken: string;
+}
+
+async function signUp(user_id: string, password: string): Promise<IToken> {
+  await checkUserExists(user_id);
+
+  const hashedPassword = await hashPassword(password);
+
+  const user = await createUser(user_id, hashedPassword);
+
+  const uid = user.getDataValue('id');
+
+  const accessToken = createToken('access', { uid });
+  const refreshToken = createToken('refresh', { uid });
+
+  return { accessToken, refreshToken };
+}
+
+export default { signUp };

--- a/server/src/utils/error/error-generator.ts
+++ b/server/src/utils/error/error-generator.ts
@@ -8,12 +8,15 @@
 interface ParamType {
   message: string;
   code: string;
+  customMessage?: string;
 }
 
 export class CustomError extends Error {
   code: string;
 
-  constructor(code: string, message: string) {
+  customMessage?: string;
+
+  constructor(code: string, message: string, customMessage?: string) {
     super(message);
 
     if (Error.captureStackTrace) {
@@ -21,11 +24,12 @@ export class CustomError extends Error {
     }
 
     this.code = code;
+    this.customMessage = customMessage;
   }
 }
 
-function errorGenerator({ message, code }: ParamType): CustomError {
-  return new CustomError(code, message);
+function errorGenerator({ message, code, customMessage }: ParamType): CustomError {
+  return new CustomError(code, message, customMessage);
 }
 
 export default errorGenerator;

--- a/server/src/utils/error/error-handler.ts
+++ b/server/src/utils/error/error-handler.ts
@@ -13,27 +13,27 @@ interface ErrorType {
 function errorHandler(err: CustomError): ErrorType {
   switch (err.code) {
     case 'req/invalid-body':
-      return { statusCode: 400, errorMessage: '잘못된 요청입니다.' };
+      return { statusCode: 400, errorMessage: err.customMessage || '잘못된 요청입니다' };
     case 'req/invalid-query':
-      return { statusCode: 400, errorMessage: '잘못된 요청입니다.' };
+      return { statusCode: 400, errorMessage: err.customMessage || '잘못된 요청입니다' };
     case 'req/no-token':
-      return { statusCode: 401, errorMessage: '다시 로그인해주세요.' };
+      return { statusCode: 401, errorMessage: err.customMessage || '다시 로그인해주세요' };
     case 'req/invalid-date':
-      return { statusCode: 409, errorMessage: '올바른 날짜를 입력해주세요.' };
+      return { statusCode: 409, errorMessage: err.customMessage || '올바른 날짜를 입력해주세요' };
     case 'auth/wrong-password':
-      return { statusCode: 409, errorMessage: '비밀번호를 확인해주세요.' };
+      return { statusCode: 409, errorMessage: err.customMessage || '비밀번호를 확인해주세요' };
     case 'auth/account-not-found':
-      return { statusCode: 404, errorMessage: '없는 계정입니다.' };
+      return { statusCode: 404, errorMessage: err.customMessage || '없는 계정입니다' };
     case 'auth/token-expired':
-      return { statusCode: 401, errorMessage: '다시 로그인해주세요.' };
+      return { statusCode: 401, errorMessage: err.customMessage || '다시 로그인해주세요' };
     case 'auth/invalid-token':
-      return { statusCode: 401, errorMessage: '다시 로그인해주세요.' };
-    case 'auth/existing-email':
-      return { statusCode: 409, errorMessage: '이미 가입된 이메일입니다.' };
+      return { statusCode: 401, errorMessage: err.customMessage || '다시 로그인해주세요' };
+    case 'auth/existing-user':
+      return { statusCode: 409, errorMessage: err.customMessage || '이미 가입된 아이디입니다' };
     case 'auth/unauthorized-token':
-      return { statusCode: 409, errorMessage: '다시 로그인해주세요.' };
+      return { statusCode: 409, errorMessage: err.customMessage || '다시 로그인해주세요' };
     case 'auth/need-re-signin':
-      return { statusCode: 409, errorMessage: '다시 로그인해주세요.' };
+      return { statusCode: 409, errorMessage: err.customMessage || '다시 로그인해주세요' };
 
     default:
       return { statusCode: 500, errorMessage: '다시 시도해주세요.' };

--- a/server/src/validation/auth.ts
+++ b/server/src/validation/auth.ts
@@ -6,19 +6,37 @@ import errorHandler from 'utils/error/error-handler';
 
 import { USER } from 'config/constants';
 
-export const signInValidation = (req: Request, res: Response, next: NextFunction): void => {
+export const authValidation = (req: Request, res: Response, next: NextFunction): void => {
   try {
     const schema = Joi.object({
-      id: Joi.string().min(USER.ID_MIN_LENGTH).max(USER.ID_MAX_LENGTH).required(),
-      password: Joi.string().max(USER.PASSWORD_MAX_LENGTH).min(USER.PASSWORD_MIN_LENGTH).required(),
+      id: Joi.string()
+        .min(USER.ID_MIN_LENGTH)
+        .max(USER.ID_MAX_LENGTH)
+        .required()
+        .messages({
+          'string.min': `아이디는 ${USER.ID_MIN_LENGTH}자 이상 입력해야 합니다`,
+          'string.max': `아이디는 ${USER.ID_MAX_LENGTH}자를 넘길 수 없습니다`,
+          'any.required': `아이디를 입력해주세요`,
+        }),
+      password: Joi.string()
+        .max(USER.PASSWORD_MAX_LENGTH)
+        .min(USER.PASSWORD_MIN_LENGTH)
+        .required()
+        .messages({
+          'string.min': `비밀번호는 ${USER.PASSWORD_MIN_LENGTH}자 이상 입력해야 합니다`,
+          'string.max': `비밀번호는 ${USER.PASSWORD_MAX_LENGTH}자를 넘길 수 없습니다`,
+          'any.required': `비밀번호를 입력해주세요`,
+        }),
     });
 
     const validationResult = schema.validate(req.body);
 
     if (validationResult.error) {
+      console.log(validationResult.error.message);
       throw errorGenerator({
-        message: 'POST /api/auth - invalid body',
+        message: 'validation/auth - invalid request body',
         code: 'req/invalid-body',
+        customMessage: validationResult.error.message,
       });
     }
 


### PR DESCRIPTION
<!--
======== Pull Request 자가 체크 리스트 ========
1. 작업 내용에 대해 lint 체크를 완료하였다.
2. 주석 및 불필요한 콘솔 로그를 지웠다.
3. 오타를 확인했다.
4. 버그가 없는지 충분히 테스트해보았다.
5. (프론트엔드) UI에서 기획과 다른 부분은 없는지 확인했다.
-->

## 개요 <!-- 필수 -->

회원가입 API

## 이슈 번호 <!-- 필수 -->

- #26 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->

* 유틸함수 `error-generator`에 커스텀 메시지 추가
* 로그인을 위한 `signInValidatoin`함수가 회원가입에도 똑같이 적용되어 `authValidation`으로 통일
* 회원가입 API
* User 스키마 INSERT 시 `phone` 컬럼 옵셔널하게 수정

## 참고사항

백엔드의 유틸함수 `error-generator` 함수에 커스텀 메세지를 보내는 기능을 추가했습니다. optional이라 원래 코드와 배치되는 부분은 없을 거에요(아마도..) 특정 상황에만 필요한 메세지를 보내고 싶다면 사용하면 됩니다. `customMessage`라는 이름의 인자로 넘겨주면 사용가능 합니다.

## 추가 구현 필요사항

* GitHub OAuth

## 스크린샷 <!-- 클라이언트 작업의 경우 필수 -->
