### PR TITLE
Feature/#27 인증 및 토큰 재발행 API

### DIFF
--- a/server/src/controllers/auth.ts
+++ b/server/src/controllers/auth.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 import authService from 'services/auth';
 
 import errorHandler from 'utils/error/error-handler';
+import { getAccessToken, getRefreshToken } from 'utils/jwt';
 
 interface IReqBody {
   id: string;
@@ -15,10 +16,34 @@ export const signIn = async (req: Request, res: Response): Promise<void> => {
 
     const { accessToken, refreshToken } = await authService.signIn(id, password);
 
-    res.cookie('_rt', refreshToken, { httpOnly: true });
+    res.cookie('rteofkreensh', refreshToken, { httpOnly: true });
     res.status(200).json({ accessToken });
   } catch (err) {
     console.log(err);
+    const { statusCode, errorMessage } = errorHandler(err);
+    res.status(statusCode).json({ errorMessage });
+  }
+};
+
+export const checkAuth = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { redirect } = req.query;
+
+    const accessToken = getAccessToken(req.headers.authorization);
+    const refreshToken = getRefreshToken(req.cookies);
+
+    const { newAccessToken, isAccessTokenExpired } = await authService.checkAuth(accessToken, refreshToken);
+
+    if (redirect) {
+      res.status(200).json({ requestAgain: true, newAccessToken });
+      return;
+    }
+
+    const result = isAccessTokenExpired ? { newAccessToken } : {};
+    res.status(200).json(result);
+  } catch (err) {
+    console.log(err);
+    res.clearCookie('_rt');
     const { statusCode, errorMessage } = errorHandler(err);
     res.status(statusCode).json({ errorMessage });
   }

--- a/server/src/controllers/user.ts
+++ b/server/src/controllers/user.ts
@@ -15,7 +15,7 @@ export const signUp = async (req: Request, res: Response): Promise<void> => {
 
     const { accessToken, refreshToken } = await userService.signUp(id, password);
 
-    res.cookie('_rt', refreshToken, { httpOnly: true });
+    res.cookie('rteofkreensh', refreshToken, { httpOnly: true });
     res.status(201).json({ accessToken });
   } catch (err) {
     console.log(err);

--- a/server/src/middlewares/testMiddleware.ts
+++ b/server/src/middlewares/testMiddleware.ts
@@ -1,7 +1,0 @@
-import { Request, Response, NextFunction } from 'express';
-
-function testMiddleware(req: Request, res: Response, next: NextFunction): void {
-  next();
-}
-
-export default testMiddleware;

--- a/server/src/middlewares/validateToken.ts
+++ b/server/src/middlewares/validateToken.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction } from 'express';
+
+import { getAccessToken, getRefreshToken, checkTokenExpiration } from 'utils/jwt';
+import errorGenerator from 'utils/error/error-generator';
+import errorHandler from 'utils/error/error-handler';
+
+async function validateToken(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const accessToken = getAccessToken(req.headers.authorization);
+    const refreshToken = getRefreshToken(req.cookies);
+
+    if (!accessToken || !refreshToken) {
+      throw errorGenerator({
+        message: 'No token',
+        code: 'req/no-token',
+      });
+    }
+
+    const isTokenExpired = await checkTokenExpiration('access', accessToken);
+
+    if (isTokenExpired) {
+      res.redirect(303, '/api/auth?redirect=true');
+      return;
+    }
+
+    next();
+  } catch (err) {
+    console.log(err);
+    const { statusCode, errorMessage } = errorHandler(err);
+    res.status(statusCode).json({ errorMessage });
+  }
+}
+
+export default validateToken;

--- a/server/src/routes/auth/index.ts
+++ b/server/src/routes/auth/index.ts
@@ -1,10 +1,15 @@
 import { Router } from 'express';
 
-import { signIn } from 'controllers/auth';
+import { signIn, checkAuth } from 'controllers/auth';
+import validateToken from 'middlewares/validateToken';
 import { authValidation } from 'validation/auth';
 
 const router = Router();
 
 router.post('/', authValidation, signIn);
+router.get('/', checkAuth);
+router.get('/test', validateToken, (req, res) => {
+  res.status(200).json({ message: 'validateToken 미들웨어 테스트 성공' });
+});
 
 export default router;

--- a/server/src/services/auth.ts
+++ b/server/src/services/auth.ts
@@ -1,12 +1,17 @@
 import { getUser } from 'repositories/auth';
 
 import errorGenerator from 'utils/error/error-generator';
-import { createToken } from 'utils/jwt';
+import { checkTokenExpiration, decodeToken, createToken } from 'utils/jwt';
 import { checkPassword } from 'utils/crypto';
 
 interface IToken {
   accessToken: string;
   refreshToken: string;
+}
+
+interface Ic {
+  isAccessTokenExpired: boolean;
+  newAccessToken: string;
 }
 
 async function signIn(user_id: string, password: string): Promise<IToken> {
@@ -30,4 +35,28 @@ async function signIn(user_id: string, password: string): Promise<IToken> {
   return { accessToken, refreshToken };
 }
 
-export default { signIn };
+async function checkAuth(accessToken: string, refreshToken: string): Promise<Ic> {
+  if (!accessToken || !refreshToken) {
+    throw errorGenerator({
+      message: 'GET /api/auth - no token',
+      code: 'req/no-token',
+    });
+  }
+
+  const isAccessTokenExpired = await checkTokenExpiration('access', accessToken);
+  const isRefreshTokenExpired = await checkTokenExpiration('refresh', refreshToken);
+
+  if (isAccessTokenExpired && isRefreshTokenExpired) {
+    throw errorGenerator({
+      code: 'auth/token-expired',
+      message: 'All tokens have expired',
+    });
+  }
+
+  const { uid } = decodeToken('refresh', refreshToken) as { uid: string };
+  const newAccessToken = createToken('access', { uid });
+
+  return { newAccessToken, isAccessTokenExpired };
+}
+
+export default { signIn, checkAuth };

--- a/server/src/utils/jwt.ts
+++ b/server/src/utils/jwt.ts
@@ -33,10 +33,10 @@ export const decodeToken = (type: TokenType, token: string): JwtPayload => {
   const secret = type === 'access' ? ACCESS_TOKEN_SECRET : REFRESH_TOKEN_SECRET;
   const decoded = jwt.verify(token, secret);
 
-  if (typeof decoded === 'string') {
+  if (typeof decoded === 'string' || !decoded.uid) {
     throw errorGenerator({
       code: 'auth/invalid-token',
-      message: 'Invalid token',
+      message: 'jwt - invalid token',
     });
   }
 
@@ -55,6 +55,11 @@ export const getAccessToken = (authorization: string | void): string => {
   return authorization.split('Bearer ')[1];
 };
 
+export const getRefreshToken = (cookies: { rteofkreensh: string }): string => {
+  if (!cookies.rteofkreensh) return '';
+  return cookies.rteofkreensh;
+};
+
 export const checkTokenExpiration = (type: TokenType, token: string): Promise<boolean> => {
   return new Promise((resolve, reject) => {
     const secret = type === 'access' ? ACCESS_TOKEN_SECRET : REFRESH_TOKEN_SECRET;
@@ -65,7 +70,7 @@ export const checkTokenExpiration = (type: TokenType, token: string): Promise<bo
       if (err) {
         const error = errorGenerator({
           code: 'auth/invalid-token',
-          message: 'Invalid token',
+          message: 'jwt - invalid token',
         });
         reject(error);
       }
@@ -77,17 +82,10 @@ export const checkTokenExpiration = (type: TokenType, token: string): Promise<bo
 export const getUIDFromToken = (token: string): string => {
   const decoded = jwt.decode(token);
 
-  if (!decoded) {
+  if (!decoded || typeof decoded === 'string') {
     throw errorGenerator({
       code: 'auth/invalid-token',
-      message: 'Invalid token',
-    });
-  }
-
-  if (typeof decoded === 'string') {
-    throw errorGenerator({
-      code: 'auth/invalid-token',
-      message: 'Invalid token',
+      message: 'jwt - invalid token',
     });
   }
 


### PR DESCRIPTION
<!--
======== Pull Request 자가 체크 리스트 ========
1. 작업 내용에 대해 lint 체크를 완료하였다.
2. 주석 및 불필요한 콘솔 로그를 지웠다.
3. 오타를 확인했다.
4. 버그가 없는지 충분히 테스트해보았다.
5. (프론트엔드) UI에서 기획과 다른 부분은 없는지 확인했다.
-->

## 개요 <!-- 필수 -->

인증 여부 확인 및 토큰 재발행 API

## 이슈 번호 <!-- 필수 -->

- #27 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->

* jwt 유틸 리프레시 토큰을 받아오는 함수 추가 및 코드 정리
* HTTP 쿠키에 저장되는 리프레시 토큰 이름 수정 'rteofkreensh' (refresh + token)
* 토큰 검증 미들웨어 (validateToken)
* 인증 여부 체크 API

## 참고사항

앞으로 회원가입, 로그인, 인증여부 제외한 모든 API에서 `validateToken` 미들웨어를 사용하면 인증받은 요청인지 확인 할 수 있습니다.
인증 여부 체크 API (`GET` /api/auth)의 경우에는 웹 어플리케이션에 최초 진입시 실행해서 로그인 여부를 판단하면 됩니다.
토큰은 accessToken을 localStorage에 저장하고, 요청시에 `req.headers.Authorization` 에 `Bearer <token>`의 형태로 넣어서 보내면 됩니다.

테스트 요령
1. 인증여부 API 테스트
<img width="960" alt="스크린샷 2021-08-16 오전 1 09 53" src="https://user-images.githubusercontent.com/35324795/129484964-f2749d07-7e4c-4ab2-93f8-4ce538604eac.png">
(토큰 만료시간은 30분이기 때문에 적게 만드는 것을 추천합니다. `utils/jwt` 파일에서
```
const ACCESS_TOKEN_EXPIRE_DATE = Math.floor(Date.now() / 1000) + 60 * 30;
```
`60 * 30`부분이 30분을 의미하기 때문에 5초나 10초 정도로 바꾸고 테스트하면 정확하게 테스트 할 수 있습니다.
2. 토큰 검증 미들웨어 테스트
<img width="961" alt="스크린샷 2021-08-16 오전 1 12 07" src="https://user-images.githubusercontent.com/35324795/129485025-7dc3c2b5-f181-4082-bddc-fd484ec4a111.png">
1번에서 얻은 토큰을 만료되기 전, 만료되고 나서 보내면 됩니다. 만료가 되었다면 requestAgain과 newAccessToken을 반환하고, 올바른 토큰이라면 성공 메세지를 보냅니다.


## 추가 구현 필요사항

## 스크린샷 <!-- 클라이언트 작업의 경우 필수 -->
