### PR TITLE
Feature/#73 백엔드 검색 및 카테고리 아이템리스트 합치기

### DIFF
--- a/server/src/controllers/items.ts
+++ b/server/src/controllers/items.ts
@@ -4,12 +4,12 @@ import itemService from 'services/items';
 
 import errorHandler from 'utils/error/error-handler';
 
-type IRequest = Request<
-  unknown,
-  unknown,
-  unknown,
-  { categoryId: string; type: string; pageId: number; search: string }
->;
+interface IQuery {
+  categoryId: string;
+  type: string;
+  pageId: number;
+  search: string;
+}
 
 export const getMainItems = async (req: Request, res: Response): Promise<void> => {
   try {
@@ -22,7 +22,7 @@ export const getMainItems = async (req: Request, res: Response): Promise<void> =
   }
 };
 
-export const getItems = async (req: IRequest, res: Response): Promise<void> => {
+export const getItems = async (req: Request<unknown, unknown, unknown, IQuery>, res: Response): Promise<void> => {
   const { categoryId, pageId, type, search } = req.query;
   try {
     const items = await itemService.getItems(categoryId, pageId, type, search);

--- a/server/src/controllers/items.ts
+++ b/server/src/controllers/items.ts
@@ -4,7 +4,12 @@ import itemService from 'services/items';
 
 import errorHandler from 'utils/error/error-handler';
 
-type IRequest = Request<unknown, unknown, unknown, { categoryId: string; type: string; pageId: number }>;
+type IRequest = Request<
+  unknown,
+  unknown,
+  unknown,
+  { categoryId: string; type: string; pageId: number; search: string }
+>;
 
 export const getMainItems = async (req: Request, res: Response): Promise<void> => {
   try {
@@ -17,10 +22,10 @@ export const getMainItems = async (req: Request, res: Response): Promise<void> =
   }
 };
 
-export const getCategoryItems = async (req: IRequest, res: Response): Promise<void> => {
-  const { categoryId, pageId, type } = req.query;
+export const getItems = async (req: IRequest, res: Response): Promise<void> => {
+  const { categoryId, pageId, type, search } = req.query;
   try {
-    const items = await itemService.categoryItems(categoryId, pageId, type);
+    const items = await itemService.getItems(categoryId, pageId, type, search);
     res.status(200).json(items);
   } catch (err) {
     console.log(err);

--- a/server/src/repositories/items.ts
+++ b/server/src/repositories/items.ts
@@ -78,4 +78,49 @@ const getCategoryItems = async (
   return items;
 };
 
-export default { getMainItems, getCategoryItems };
+const getSearchItems = async (
+  pageId: number,
+  order: string[][],
+  regExp: string,
+): Promise<Model<ItemAttributes, ItemCreationAttributes>[]> => {
+  const items = await db.Item.findAll({
+    attributes: [
+      'id',
+      'title',
+      'thumbnail',
+      'price',
+      ['sale_percent', 'salePercent'],
+      'amount',
+      ['is_green', 'isGreen'],
+    ],
+    order: order as Order,
+    where: {
+      title: {
+        [Op.regexp]: regExp,
+      },
+    },
+    offset: (pageId - 1) * 8 + 1,
+    limit: 12,
+    include: [
+      {
+        model: db.Category,
+        attributes: [],
+      },
+    ],
+  });
+
+  if (!items) {
+    throw errorGenerator({
+      message: 'POST /api/items - items not found',
+      code: 'items/not-found',
+    });
+  }
+
+  items.forEach(v => {
+    v.setDataValue('isGreen', v.getDataValue('isGreen') === 1);
+  });
+
+  return items;
+};
+
+export default { getMainItems, getCategoryItems, getSearchItems };

--- a/server/src/routes/items/index.ts
+++ b/server/src/routes/items/index.ts
@@ -1,9 +1,9 @@
 import { Router } from 'express';
 
-import { getCategoryItems, getMainItems } from 'controllers/items';
+import { getItems, getMainItems } from 'controllers/items';
 
 const router = Router();
 router.get('/main', getMainItems);
-router.get('/category', getCategoryItems);
+router.get('/', getItems);
 
 export default router;

--- a/server/src/services/items.ts
+++ b/server/src/services/items.ts
@@ -2,6 +2,7 @@ import itemRepository from 'repositories/items';
 import { ItemAttributes, ItemCreationAttributes } from 'models/item';
 import { Model } from 'sequelize';
 import errorGenerator from 'utils/error/error-generator';
+import { getRegExp, engToKor } from 'korean-regexp';
 
 async function mainItems(): Promise<Model<ItemAttributes, ItemCreationAttributes>[][]> {
   const items = await Promise.all([
@@ -13,23 +14,24 @@ async function mainItems(): Promise<Model<ItemAttributes, ItemCreationAttributes
   return items;
 }
 
-async function categoryItems(
+async function getItems(
   categoryId: string,
   pageId = 1,
   type: string,
+  search: string,
 ): Promise<Model<ItemAttributes, ItemCreationAttributes>[]> {
   if (
-    !(
-      categoryId ||
-      type ||
-      categoryId.length === 6 ||
-      ['recommend', 'popular', 'recent ', 'cheap', 'expensive'].includes(type)
-    )
-  )
+    (categoryId && search) ||
+    (!categoryId && !search) ||
+    (categoryId && categoryId.length !== 6) ||
+    Number.isNaN(pageId)
+  ) {
     throw errorGenerator({
       message: 'POST /api/item - no exist querystring',
       code: 'item/no-exist-querystring',
     });
+  }
+
   const order = [];
   //  recommend 수정 예정
   if (type === 'recommend') order.push(['sale_count', 'DESC']);
@@ -37,12 +39,27 @@ async function categoryItems(
   else if (type === 'recent') order.push(['updatedAt', 'DESC']);
   else if (type === 'cheap') order.push(['price', 'ASC']);
   else if (type === 'expensive') order.push(['price', 'DESC']);
-  const categoryReg = categoryId.slice(2, 4) === '00' ? categoryId.slice(0, 2) : categoryId.slice(0, 4);
-  const items = await itemRepository.getCategoryItems(pageId, order, categoryReg);
+
+  let items;
+  if (categoryId) {
+    let categoryReg = '';
+    if (categoryReg) {
+      if (categoryId.slice(2, 4) === '00') categoryReg = categoryId.slice(0, 2);
+      else categoryId.slice(0, 4);
+    }
+    items = await itemRepository.getCategoryItems(pageId, order, categoryReg);
+  } else {
+    const regExp = String(
+      getRegExp(engToKor(search), {
+        initialSearch: true,
+      }),
+    );
+    items = await itemRepository.getSearchItems(pageId, order, regExp.substring(0, regExp.length - 2).slice(1));
+  }
   return items;
 }
 
 export default {
   mainItems,
-  categoryItems,
+  getItems,
 };

--- a/server/src/services/items.ts
+++ b/server/src/services/items.ts
@@ -10,7 +10,7 @@ async function mainItems(): Promise<Model<ItemAttributes, ItemCreationAttributes
     itemRepository.getMainItems([['updatedAt', 'DESC']], 8),
     itemRepository.getMainItems([['sale_count', 'DESC']], 4),
   ]);
-  // 3번째 recommend 수정 예정
+  // TODO 3번째 recommend 수정 예정
   return items;
 }
 
@@ -33,7 +33,7 @@ async function getItems(
   }
 
   const order = [];
-  //  recommend 수정 예정
+  // TODO recommend 수정 예정
   if (type === 'recommend') order.push(['sale_count', 'DESC']);
   else if (type === 'popular') order.push(['sale_count', 'DESC']);
   else if (type === 'recent') order.push(['updatedAt', 'DESC']);


### PR DESCRIPTION
<!--
======== Pull Request 자가 체크 리스트 ========
1. 작업 내용에 대해 lint 체크를 완료하였다.
2. 주석 및 불필요한 콘솔 로그를 지웠다.
3. 오타를 확인했다.
4. 버그가 없는지 충분히 테스트해보았다.
5. (프론트엔드) UI에서 기획과 다른 부분은 없는지 확인했다.
-->

## 개요 <!-- 필수 -->


## 이슈 번호 <!-- 필수 -->

백엔드 검색 및  카테고리 아이템리스트 합치기  #73 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->

백엔드 검색 아이템 리스트 만들기 + 카테고리랑 합치기

## 참고사항

전체메뉴(000000)가있는걸 나중에 알아서 프론트에서 커밋을 해버렸습니다.. 죄송합니다

- GET /api/items/main 메인 페이지 아이템 불러오기
- GET /api/items?categoryId=008000&type=recommend&pageId=2 카테고리 아이템 불러오기
- GET /api/items?type=recommend&pageId=1&search=슬리퍼 검색 아이템 불러오기
    type에는 'recommend', 'popular', 'recent ', 'cheap', 'expensive'가 있습니다

`categoryId`와 `search` 파라미터는 둘 중 하나만 들어가야 합니다.

## 추가 구현 필요사항

프론트

## 스크린샷 <!-- 클라이언트 작업의 경우 필수 -->
