### PR TITLE
feature/#82 우아한 컴포넌트 리팩토링

### DIFF
--- a/client/src/lib/woowahan-components/components/woowahan-component.tsx
+++ b/client/src/lib/woowahan-components/components/woowahan-component.tsx
@@ -1,19 +1,23 @@
-import React, { FC } from 'react';
+import React from 'react';
 import { compile, serialize, stringify, middleware } from 'stylis';
 
 import useTheme from '../hooks/use-theme';
 import generateId from '../utils/generate-id';
-import parseString, { IProps, ExpType } from '../utils/parse-string';
-import { IThemeContext } from './theme-provider';
+import parseString, { ExpType } from '../utils/parse-string';
 
-export type TaggedTemplateType = (styleString: TemplateStringsArray, ...exps: ExpType) => FC<IProps>;
-type ElementProps = { [key: string]: unknown };
+export type WoowahanComponent = (
+  styleString: TemplateStringsArray,
+  ...exps: ExpType
+) => (props: ElementProps) => React.ReactElement;
 
-const woowahanComponent = (tag: string): TaggedTemplateType => {
-  const classMap = new Map<string, string>();
+type ElementProps = Record<string, unknown>;
 
-  return (styleString: TemplateStringsArray, ...exps: ExpType): FC => {
-    const FuntionComponent: FC<IThemeContext> = props => {
+const woowahanComponent =
+  (tag: string): WoowahanComponent =>
+  (styleString: TemplateStringsArray, ...exps: ExpType): ((props: ElementProps) => React.ReactElement) => {
+    const classMap = new Map<string, string>();
+    const FuntionComponent = (props: ElementProps): React.ReactElement => {
+      const { children } = props;
       const theme = useTheme();
       const parsedString = parseString(styleString, exps, { theme, ...props });
 
@@ -47,28 +51,26 @@ const woowahanComponent = (tag: string): TaggedTemplateType => {
         });
       }
 
-      const { children } = props;
       if (props.className) {
-        className += ` ${props.className}`;
+        const a = props.className as string;
+        className += ` ${a}`;
       }
 
       const newProps: ElementProps = {};
 
       Object.entries(props).forEach(([key, value]) => {
         if (typeof value === 'boolean') {
-          newProps[key] = (value as boolean).toString();
+          newProps[key] = value.toString();
         } else {
           newProps[key] = value;
         }
       });
 
-      const ReactElement = React.createElement(tag, { ...newProps, className }, children);
-
+      const ReactElement = React.createElement(tag, { ...newProps, className }, children as React.ReactNode[]);
       return ReactElement;
     };
 
     return FuntionComponent;
   };
-};
 
 export default woowahanComponent;

--- a/client/src/lib/woowahan-components/components/woowahan-component.tsx
+++ b/client/src/lib/woowahan-components/components/woowahan-component.tsx
@@ -5,6 +5,8 @@ import useTheme from '../hooks/use-theme';
 import generateId from '../utils/generate-id';
 import parseString, { ExpType } from '../utils/parse-string';
 
+import reactProps from '../configs/react-props';
+
 export type WoowahanComponent = (
   styleString: TemplateStringsArray,
   ...exps: ExpType
@@ -60,7 +62,10 @@ const woowahanComponent =
 
       Object.entries(props).forEach(([key, value]) => {
         if (typeof value === 'boolean') {
-          newProps[key] = value.toString();
+          if (!reactProps.includes(key)) newProps[key.toLowerCase()] = value.toString();
+          else newProps[key] = value.toString();
+        } else if (!reactProps.includes(key)) {
+          newProps[key.toLowerCase()] = value;
         } else {
           newProps[key] = value;
         }

--- a/client/src/lib/woowahan-components/configs/react-props.ts
+++ b/client/src/lib/woowahan-components/configs/react-props.ts
@@ -1,0 +1,28 @@
+const reactProps = [
+  'onClick',
+  'onContextMenu',
+  'onDoubleClick',
+  'onDrag',
+  'onDragEnd',
+  'onDragEnter',
+  'onDragExit',
+  'onDragLeave',
+  'onDragOver',
+  'onDragStart',
+  'onDrop',
+  'onMouseDown',
+  'onMouseEnter',
+  'onMouseLeave',
+  'onMouseMove',
+  'onMouseOut',
+  'onMouseOver',
+  'onMouseUp',
+  'className',
+  'onMouseLeave',
+  'onChange',
+  'onFocus',
+  'onBlur',
+  'onMouseMove',
+];
+
+export default reactProps;

--- a/client/src/lib/woowahan-components/index.ts
+++ b/client/src/lib/woowahan-components/index.ts
@@ -1,11 +1,11 @@
-import woowahanComponent, { TaggedTemplateType } from './components/woowahan-component';
+import woowahanComponent, { WoowahanComponent } from './components/woowahan-component';
 import tags from './configs/tag-names';
 
 export { default as createGlobalStyle } from './components/create-global-style';
 export { default as ThemeProvider } from './components/theme-provider';
 
 export interface IWoowahan {
-  [key: string]: TaggedTemplateType;
+  [key: string]: WoowahanComponent;
 }
 
 const styled: IWoowahan = {};


### PR DESCRIPTION
<!--
======== Pull Request 자가 체크 리스트 ========
1. 작업 내용에 대해 lint 체크를 완료하였다.
2. 주석 및 불필요한 콘솔 로그를 지웠다.
3. 오타를 확인했다.
4. 버그가 없는지 충분히 테스트해보았다.
5. (프론트엔드) UI에서 기획과 다른 부분은 없는지 확인했다.
-->

## 개요 <!-- 필수 -->

우아한 컴포넌트 리팩토링

## 이슈 번호 <!-- 필수 -->

- #82 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->

* 반환값 React.ReactElement로 변경
* React에 기본적으로 적용된 props를 제외한 나머지는 camelCase에서 lowercase로 바꿔서 props로 넘김

## 참고사항

반환값이 기존에 `React.FC`라서 기본 `onChange` 라던가 `onClick`과 같은 것들이 자동완성이 안되는 줄 알고 `React.ReactElement`를 반환하게 만들었는데, 그 문제가 아니었네요... 그래도 일단 의미는 `FC` 보다는 `ReactElement`가 맞는 것 같아서 그렇게 바꾼거라도 올립니다.

**바꿔서 타입 에러가 발생할 수 있으니 꼭 한번 실행해주세요**

## 추가 구현 필요사항

## 스크린샷 <!-- 클라이언트 작업의 경우 필수 -->
