### PR TITLE
Feature/#108 아이템 리스트 페이지 추천순 정렬

### DIFF
--- a/client/src/utils/api/item.ts
+++ b/client/src/utils/api/item.ts
@@ -11,6 +11,8 @@ export const getMainItem = (): Promise<AxiosResponse> => {
 
 export const getListItem = ({ categoryId, pageId, type, search }: IItemState): Promise<AxiosResponse> => {
   let url = '/api/items?';
+  const visited = localStorage.getItem('visited')?.split(',');
+
   const arr = [];
   if (categoryId) arr.push(`categoryId=${categoryId}&`);
   if (pageId) arr.push(`pageId=${pageId}&`);
@@ -18,7 +20,7 @@ export const getListItem = ({ categoryId, pageId, type, search }: IItemState): P
   if (search) arr.push(`search=${search}&`);
   url += arr.join('');
   url = url.slice(0, url.length - 1);
-  return client.get<IListItem>(url);
+  return client.post<IListItem>(url, visited);
 };
 
 export const getItem = ({ id }: { id: string }): Promise<AxiosResponse> => client.get(`/api/items/${id}`);

--- a/server/src/controllers/items.ts
+++ b/server/src/controllers/items.ts
@@ -28,10 +28,10 @@ export const getMainItems = async (req: Request, res: Response): Promise<void> =
   }
 };
 
-export const getItems = async (req: Request<unknown, unknown, unknown, IQuery>, res: Response): Promise<void> => {
+export const getItems = async (req: Request<unknown, unknown, string[], IQuery>, res: Response): Promise<void> => {
   const { categoryId, pageId, type, search } = req.query;
   try {
-    const data = await itemService.getItems(categoryId, pageId, type, search);
+    const data = await itemService.getItems(categoryId, pageId, type, search, req.body);
     const { items, totalCount, pageCount } = data;
     res.status(200).json({ items, totalCount, pageCount });
   } catch (err) {

--- a/server/src/routes/items/index.ts
+++ b/server/src/routes/items/index.ts
@@ -5,6 +5,6 @@ import { getItems, getMainItems, getItem } from 'controllers/items';
 const router = Router();
 router.post('/main', getMainItems);
 router.get('/:id', getItem);
-router.get('/', getItems);
+router.post('/', getItems);
 
 export default router;

--- a/server/src/services/items.ts
+++ b/server/src/services/items.ts
@@ -49,9 +49,6 @@ async function getItems(
     });
 
   const order = [];
-  // TODO: recommend 수정 예정
-  // if (type === 'recommend') order.push([Sequelize.literal('rand()')]);
-  // else
   if (type === 'popular') order.push(['sale_count', 'DESC']);
   else if (type === 'recent') order.push(['updatedAt', 'DESC']);
   else if (type === 'cheap') order.push(['price', 'ASC']);

--- a/server/src/services/items.ts
+++ b/server/src/services/items.ts
@@ -25,7 +25,7 @@ async function mainItems(visited: string[]): Promise<IMainItems> {
   const [popularItems, newItems, recommendItems] = await Promise.all([
     itemRepository.getMainItems([['sale_count', 'DESC']], 4),
     itemRepository.getMainItems([['updatedAt', 'DESC']], 8),
-    itemRepository.getRecommendItems(visited),
+    itemRepository.getRecommendItems(visited, false),
   ]);
   return { popularItems, newItems, recommendItems };
 }

--- a/server/src/services/items.ts
+++ b/server/src/services/items.ts
@@ -30,7 +30,13 @@ async function mainItems(visited: string[]): Promise<IMainItems> {
   return { popularItems, newItems, recommendItems };
 }
 
-async function getItems(categoryId: string, pageId = 1, type: ItemType, search: string): Promise<IItemsData> {
+async function getItems(
+  categoryId: string,
+  pageId = 1,
+  type: ItemType,
+  search: string,
+  visited: string[],
+): Promise<IItemsData> {
   if (
     (categoryId && search) ||
     (!categoryId && !search) ||
@@ -44,20 +50,25 @@ async function getItems(categoryId: string, pageId = 1, type: ItemType, search: 
 
   const order = [];
   // TODO: recommend 수정 예정
-  if (type === 'recommend') order.push(['sale_count', 'DESC']);
-  else if (type === 'popular') order.push(['sale_count', 'DESC']);
+  // if (type === 'recommend') order.push([Sequelize.literal('rand()')]);
+  // else
+  if (type === 'popular') order.push(['sale_count', 'DESC']);
   else if (type === 'recent') order.push(['updatedAt', 'DESC']);
   else if (type === 'cheap') order.push(['price', 'ASC']);
   else if (type === 'expensive') order.push(['price', 'DESC']);
 
-  let data;
+  let data: IItemsData;
   if (categoryId) {
     let categoryReg = '';
     if (categoryId === '000000') categoryReg = '';
     else if (categoryId.slice(2, 4) === '00') categoryReg = categoryId.slice(0, 2);
     else categoryReg = categoryId.slice(0, 4);
 
-    data = await itemRepository.getCategoryItems(pageId, order, categoryReg);
+    if (type === 'recommend') {
+      data = await itemRepository.getCategoryRecommendItems(pageId, categoryReg, visited);
+    } else {
+      data = await itemRepository.getCategoryItems(pageId, order, categoryReg);
+    }
   } else {
     const regExp = String(
       getRegExp(engToKor(search), {


### PR DESCRIPTION
<!--
======== Pull Request 자가 체크 리스트 ========
1. 작업 내용에 대해 lint 체크를 완료하였다.
2. 주석 및 불필요한 콘솔 로그를 지웠다.
3. 오타를 확인했다.
4. 버그가 없는지 충분히 테스트해보았다.
5. (프론트엔드) UI에서 기획과 다른 부분은 없는지 확인했다.
-->

## 개요 <!-- 필수 -->

카테고리별 아이템 리스트 페이지에서 유저 맞춤 추천순으로 아이템을 볼 수 있는 기능을 추가했습니다
전체적인 추천 데이터 정렬 방식을 개선했습니다

## 이슈 번호 <!-- 필수 -->

 - #108 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->
 - 클라이언트
   - 카테고리별 아이템 리스트 페이지에서 추천순으로 아이템을 볼 수 있게 되었습니다
   - /api/items 요청을 get에서 post로 변경하고 body로 열람기록을 전송합니다
 - 서버
   - /api/items 요청을 post로 받도록 변경했습니다
   - 카테고리별 추천 아이템 함수를 추가했습니다
   - 중복된 아이템이 추천되는 문제를 해결했습니다
   - 추천 데이터 정렬 방식을 개선하여 유사도 내림차순으로 상품이 정렬되게 했습니다
  
## 참고사항

- 메인 화면 상품 추천에서도 같은 함수를 사용하기 때문에 메인 화면 역시 유사도 내림차순으로 추천 상품을 보여주게 개선되었습니다
- 해당 유저와 관련이 없는 아이템(열람기록과 유사도 낮음)은 가장 뒤에 위치하게 됩니다

## 추가 구현 필요사항
 - 없음

## 스크린샷 <!-- 클라이언트 작업의 경우 필수 -->

### 열람기록
![image](https://user-images.githubusercontent.com/86910140/130456580-eab8bbf7-5bae-46f8-86ca-b70103d2a255.png)


### 문구 - 엽서. 굿 / 노트. 굿과 관련된 아이템 추천순
![image](https://user-images.githubusercontent.com/86910140/130455737-03a39a4d-ae3b-42e4-9dfa-628ceea8a5cd.png)

### 메인화면에서 유사도 내림차순이 적용된 모습
![image](https://user-images.githubusercontent.com/86910140/130456041-8add8364-9c23-43cc-9022-f26672737f54.png)

