### PR TITLE
Feature/#102 이미지 확대 뷰어 개발

### DIFF
--- a/client/src/components/image-viewer/index.tsx
+++ b/client/src/components/image-viewer/index.tsx
@@ -1,0 +1,111 @@
+import React, { FC, useCallback, useRef, MouseEvent } from 'react';
+import styled from 'lib/woowahan-components';
+
+interface ImageViewerProps {
+  imgSrc: string;
+  imgWidth: number;
+  imgHeight: number;
+}
+
+const Wrapper = styled.div`
+  position: relative;
+
+  .image-lens {
+    position: absolute;
+    border: 1px solid ${props => props.theme?.colorGreyLight};
+    background-color: rgba(255, 255, 255, 0.3);
+    width: 200px;
+    height: 200px;
+  }
+
+  .image-zoom {
+    position: absolute;
+    top: 0;
+    left: ${props => props.left as string}px;
+    width: ${props => props.imgWidth as string}px;
+    height: ${props => props.imgWidth as string}px;
+    background-image: url(${props => props.targetImg as string});
+    background-size: ${props => props.resultSize as string};
+    background-repeat: none;
+  }
+`;
+
+const ImageViewer: FC<ImageViewerProps> = ({ imgSrc, imgWidth, imgHeight }) => {
+  const imgRef = useRef<HTMLImageElement>(null);
+  const lensRef = useRef<HTMLDivElement>(null);
+  const zoomRef = useRef<HTMLDivElement>(null);
+
+  const getCursorPos = (e: MouseEvent): { x: number; y: number } => {
+    if (!imgRef.current) return { x: 0, y: 0 };
+
+    const imgClient = imgRef.current.getBoundingClientRect();
+
+    const x = e.pageX - imgClient.left - window.pageXOffset;
+    const y = e.pageY - imgClient.top - window.pageYOffset;
+
+    return { x, y };
+  };
+
+  const moveLens = useCallback((e: MouseEvent) => {
+    if (!imgRef.current || !lensRef.current || !zoomRef.current) return;
+    e.preventDefault();
+
+    const img = imgRef.current;
+    const lens = lensRef.current;
+    const zoom = zoomRef.current;
+
+    const cursorPos = getCursorPos(e);
+
+    if (cursorPos.x > img.width - 30 || cursorPos.x < 30 || cursorPos.y > img.height - 30 || cursorPos.y < 30) {
+      lens.style.display = 'none';
+      zoom.style.display = 'none';
+    } else {
+      lens.style.display = 'block';
+      zoom.style.display = 'block';
+      let x = cursorPos.x - lens.offsetWidth / 2;
+      let y = cursorPos.y - lens.offsetHeight / 2;
+
+      if (x > img.width - lens.offsetWidth) x = img.width - lens.offsetWidth;
+      if (x < 0) x = 0;
+      if (y > img.height - lens.offsetHeight) y = img.height - lens.offsetHeight;
+      if (y < 0) y = 0;
+
+      lensRef.current.style.left = `${x}px`;
+      lensRef.current.style.top = `${y}px`;
+
+      const cx = zoom.offsetWidth / lens.offsetWidth;
+      const cy = zoom.offsetHeight / lens.offsetHeight;
+
+      zoom.style.backgroundPosition = `-${x * cx}px -${y * cy}px`;
+    }
+  }, []);
+
+  const calcBgSize = () => {
+    if (!zoomRef.current || !lensRef.current) return '';
+
+    const zoom = zoomRef.current;
+    const lens = lensRef.current;
+
+    const cx = zoom.offsetWidth / lens.offsetWidth;
+    const cy = zoom.offsetHeight / lens.offsetHeight;
+
+    return `${imgWidth * cx}px ${imgHeight * cy}px`;
+  };
+
+  return (
+    <Wrapper left={imgWidth + 5} imgWidth={imgWidth} imgHeight={imgHeight} targetImg={imgSrc} resultSize={calcBgSize()}>
+      <img
+        ref={imgRef}
+        src={imgSrc}
+        alt="item-img"
+        width={`${imgWidth}px`}
+        height={`${imgHeight}px`}
+        onMouseMove={moveLens}
+      />
+      <div ref={lensRef} className="image-lens" onMouseMove={moveLens} />
+      <div ref={zoomRef} className="image-zoom" />
+    </Wrapper>
+  );
+};
+
+export default ImageViewer;

--- a/client/src/components/image-viewer/index.tsx
+++ b/client/src/components/image-viewer/index.tsx
@@ -2,6 +2,7 @@ import React, { FC, useCallback, useRef, MouseEvent } from 'react';
 import styled from 'lib/woowahan-components';
 
 interface ImageViewerProps {
+  className?: string;
   imgSrc: string;
   imgWidth: number;
   imgHeight: number;
@@ -30,7 +31,7 @@ const Wrapper = styled.div`
   }
 `;
 
-const ImageViewer: FC<ImageViewerProps> = ({ imgSrc, imgWidth, imgHeight }) => {
+const ImageViewer: FC<ImageViewerProps> = ({ className = '', imgSrc, imgWidth, imgHeight }) => {
   const imgRef = useRef<HTMLImageElement>(null);
   const lensRef = useRef<HTMLDivElement>(null);
   const zoomRef = useRef<HTMLDivElement>(null);
@@ -93,7 +94,14 @@ const ImageViewer: FC<ImageViewerProps> = ({ imgSrc, imgWidth, imgHeight }) => {
   };
 
   return (
-    <Wrapper left={imgWidth + 5} imgWidth={imgWidth} imgHeight={imgHeight} targetImg={imgSrc} resultSize={calcBgSize()}>
+    <Wrapper
+      className={className}
+      left={imgWidth + 5}
+      imgWidth={imgWidth}
+      imgHeight={imgHeight}
+      targetImg={imgSrc}
+      resultSize={calcBgSize()}
+    >
       <img
         ref={imgRef}
         src={imgSrc}

--- a/client/src/components/item-detail/info-section.tsx
+++ b/client/src/components/item-detail/info-section.tsx
@@ -1,14 +1,14 @@
 import React, { useState, useEffect, FC } from 'react';
 import styled from 'lib/woowahan-components';
+import useWindowSize from 'hooks/use-window-size';
 
 import starsTitle from 'assets/icons/stars_title.png';
 
 import { formatPrice } from 'utils';
 
 import TextButton from 'components/common/text-button';
-import ItemCounter from './item-counter';
 import ImageViewer from 'components/image-viewer';
-import useWindowSize from 'hooks/use-window-size';
+import ItemCounter from './item-counter';
 
 export interface InfoSectionProps {
   thumbnail: string;
@@ -160,7 +160,7 @@ const PaymentWrapper = styled.form`
   }
 `;
 
-const InfoSection: FC<InfoSectionProps> = ({ thumbnail, title, price, isLike, isSoldOut, onSubmitCart, onBuy }) => {
+const InfoSection: FC<InfoSectionProps> = ({ thumbnail, title, price, isSoldOut, onSubmitCart, onBuy }) => {
   const [totalPrice, setTotalPrice] = useState(price);
   const { width } = useWindowSize();
 

--- a/client/src/components/item-detail/info-section.tsx
+++ b/client/src/components/item-detail/info-section.tsx
@@ -7,6 +7,8 @@ import { formatPrice } from 'utils';
 
 import TextButton from 'components/common/text-button';
 import ItemCounter from './item-counter';
+import ImageViewer from 'components/image-viewer';
+import useWindowSize from 'hooks/use-window-size';
 
 export interface InfoSectionProps {
   thumbnail: string;
@@ -22,6 +24,10 @@ const Wrapper = styled.section`
   width: 100%;
   display: flex;
   justify-content: space-between;
+
+  .image-viewer {
+    margin-right: 50px;
+  }
 
   ${({ theme }) => theme?.tablet} {
     flex-direction: column;
@@ -41,9 +47,11 @@ const Thumbnail = styled.img`
     margin-bottom: 18px;
     margin-right: 0;
   }
+
   ${({ theme }) => theme?.mobile} {
     width: 100%;
     height: auto;
+    margin-top: 10px;
     margin-right: 0;
     margin-bottom: 18px;
   }
@@ -154,6 +162,7 @@ const PaymentWrapper = styled.form`
 
 const InfoSection: FC<InfoSectionProps> = ({ thumbnail, title, price, isLike, isSoldOut, onSubmitCart, onBuy }) => {
   const [totalPrice, setTotalPrice] = useState(price);
+  const { width } = useWindowSize();
 
   const handleCounterChange = (v: number) => {
     setTotalPrice(v);
@@ -165,7 +174,11 @@ const InfoSection: FC<InfoSectionProps> = ({ thumbnail, title, price, isLike, is
 
   return (
     <Wrapper>
-      <Thumbnail src={thumbnail} alt={title} />
+      {width >= 1200 ? (
+        <ImageViewer className="image-viewer" imgSrc={thumbnail} imgWidth={450} imgHeight={527} />
+      ) : (
+        <Thumbnail src={thumbnail} alt={title} />
+      )}
       <ItemInfo>
         <div className="top-wrapper">
           <img src={starsTitle} alt="stars-title" />


### PR DESCRIPTION
<!--
======== Pull Request 자가 체크 리스트 ========
1. 작업 내용에 대해 lint 체크를 완료하였다.
2. 주석 및 불필요한 콘솔 로그를 지웠다.
3. 오타를 확인했다.
4. 버그가 없는지 충분히 테스트해보았다.
5. (프론트엔드) UI에서 기획과 다른 부분은 없는지 확인했다.
-->

## 개요 <!-- 필수 -->

이미지 특정 영역을 확대하여 보여주는 이미지 뷰어를 개발하였습니다.

## 이슈 번호 <!-- 필수 -->

- #102 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->

- 이미지 뷰어 컴포넌트 개발
- 이미지 상세 페이지 수정

## 참고사항

- 이미지 상세 페이지에서 이미지가 가운데에 놓이면 이미지 확대 결과를 보여줄 공간이 없게 됩니다. 그래서 데스크탑 모드일 때만 작동합니다.
  - 개발자 도구로 확인하거나 창을 조금 작게 띄워서 보면 데모 데이날에 태블릿 크기로도 사람들이 많이 볼 것 같은데, 스마트 레이어에서는 마우스 호버했을 때 이벤트를, 이미지 상세 페이지에서는 이미지 뷰어를 확인하지 못하는데 이 부분을 수정하는 것은 어떤가요? 스마트 레이어에서는 터치 이벤트가 들어왔을 때를 따로 처리하고, 이미지 상세에서는 태블릿일 때도 데스크탑처럼 레이아웃을 볼 수 있게요 !
- 프론트 리팩토링이 어차피 필요할 것 같아서 상세 페이지에 넣는 것은 그런 부분은 고려하지 않았습니다!

## reference

자료를 참고해서 많이 구현하였습니다.

- 코드 : https://www.w3schools.com/howto/howto_js_image_zoom.asp
- 구현 결과물 : 쿠팡 (예 : https://www.coupang.com/vp/products/1322476307?itemId=2343903789&vendorItemId=70340462040&isAddedCart=)

## 스크린샷 <!-- 클라이언트 작업의 경우 필수 -->

![2021-08-23 22 44 30](https://user-images.githubusercontent.com/22045163/130457976-d59fad17-e5ba-4686-868d-4cea02f455fb.gif)
