### PR TITLE
Feature/#105 주문내역 페이지 프론트 api 연동

### DIFF
--- a/client/src/components/common/layout/index.tsx
+++ b/client/src/components/common/layout/index.tsx
@@ -20,7 +20,6 @@ const Wrapper = styled.div`
     display: flex;
     justify-content: flex-start;
     flex-direction: column;
-    align-items: center;
   }
 
   ${props => props.theme?.mobile} {

--- a/client/src/components/my/inquiry-period.tsx
+++ b/client/src/components/my/inquiry-period.tsx
@@ -12,7 +12,6 @@ interface InquiryPeroidProps {
   onClickThisMonth: () => void;
   onClickThreeMonth: () => void;
   select: undefined | number;
-  onSubmit: (e: React.FormEvent) => void;
 }
 
 const Wrapper = styled.div`
@@ -89,14 +88,6 @@ const DateFlex = styled.div`
   }
 `;
 
-const Button = styled.button`
-  width: 100px;
-  height: 31px;
-  font-weight: 700;
-  background-color: ${props => props.theme?.colorBlack};
-  color: ${props => props.theme?.colorWhite};
-`;
-
 const InquiryPeriod: FC<InquiryPeroidProps> = ({
   prevDate,
   setPrevDate,
@@ -108,7 +99,6 @@ const InquiryPeriod: FC<InquiryPeroidProps> = ({
   onClickThisMonth,
   onClickThreeMonth,
   select,
-  onSubmit,
 }) => {
   const btn: [string, () => void][] = [
     ['오늘', onClickToday],
@@ -119,7 +109,7 @@ const InquiryPeriod: FC<InquiryPeroidProps> = ({
   return (
     <Wrapper>
       <h3>조회기간</h3>
-      <Form onSubmit={onSubmit}>
+      <Form>
         <RegionFlex>
           {btn.map(([text, fn], idx) => (
             <button key={text} type="button" onClick={fn} className={select === idx ? 'active' : ''}>
@@ -147,7 +137,6 @@ const InquiryPeriod: FC<InquiryPeroidProps> = ({
             }}
             required
           />
-          <Button type="submit">조회</Button>
         </DateFlex>
       </Form>
     </Wrapper>

--- a/client/src/components/my/inquiry-period.tsx
+++ b/client/src/components/my/inquiry-period.tsx
@@ -135,6 +135,7 @@ const InquiryPeriod: FC<InquiryPeroidProps> = ({
             onChange={e => {
               setPrevDate(e.target.value);
             }}
+            required
           />
           <span>~</span>
           <input
@@ -144,6 +145,7 @@ const InquiryPeriod: FC<InquiryPeroidProps> = ({
             onChange={e => {
               setCurrentDate(e.target.value);
             }}
+            required
           />
           <Button type="submit">조회</Button>
         </DateFlex>

--- a/client/src/components/my/my-order-list.tsx
+++ b/client/src/components/my/my-order-list.tsx
@@ -1,55 +1,29 @@
 import styled from 'lib/woowahan-components';
 import React, { FC } from 'react';
+import { IOrder } from 'types/order';
 import MyOrder from './my-order';
 
-const dummy = [
-  {
-    createdAt: '2021-07-28',
-    thumbnail: 'https://storage.googleapis.com/bmart-5482b.appspot.com/008/198_main_04.png',
-    itemTitle: '재생지에 콩기름을 먹어요',
-    price: '3500',
-    count: 1,
-    status: '주문완료',
-  },
-  {
-    createdAt: '2021-07-28',
-    thumbnail: 'https://storage.googleapis.com/bmart-5482b.appspot.com/008/198_main_04.png',
-    itemTitle: '재생지에 콩기름을 먹어요2',
-    price: '3500',
-    count: 1,
-    status: '주문완료',
-  },
-  {
-    createdAt: '2021-07-28',
-    thumbnail: 'https://storage.googleapis.com/bmart-5482b.appspot.com/008/198_main_04.png',
-    itemTitle: '재생지에 콩기름을 먹어요3',
-    price: '3500',
-    count: 1,
-    status: '주문완료',
-  },
-  {
-    createdAt: '2021-07-28',
-    thumbnail: 'https://storage.googleapis.com/bmart-5482b.appspot.com/008/198_main_04.png',
-    itemTitle: '재생지에 콩기름을 먹어요4',
-    price: '3500',
-    count: 1,
-    status: '주문완료',
-  },
-];
+interface MyOrderListProps {
+  loading: boolean;
+  orders: IOrder[];
+  pageCount: number;
+  totalCount: number;
+}
 
 const Wrapper = styled.div`
   margin: 0 -12px;
   margin-bottom: 100px;
 `;
 
-const MyOrderList: FC = () => {
+const MyOrderList: FC<MyOrderListProps> = ({ loading, orders, pageCount, totalCount }) => {
+  // TODO: 로딩, 페이지 카운트, 토탈카운트
   return (
     <Wrapper>
-      {dummy.map(({ createdAt, itemTitle, thumbnail, price, count, status }) => (
+      {orders.map(({ createdAt, title, thumbnail, price, count, status }) => (
         <MyOrder
-          key={itemTitle}
+          key={title}
           createdAt={createdAt}
-          itemTitle={itemTitle}
+          title={title}
           thumbnail={thumbnail}
           price={price}
           count={count}

--- a/client/src/components/my/my-order-list.tsx
+++ b/client/src/components/my/my-order-list.tsx
@@ -1,12 +1,12 @@
 import styled from 'lib/woowahan-components';
 import React, { FC } from 'react';
 import { IOrder } from 'types/order';
+import Loader from 'components/common/loader';
 import MyOrder from './my-order';
 
 interface MyOrderListProps {
   loading: boolean;
   orders: IOrder[];
-  pageCount: number;
   totalCount: number;
 }
 
@@ -15,23 +15,35 @@ const Wrapper = styled.div`
   margin-bottom: 100px;
 `;
 
-const MyOrderList: FC<MyOrderListProps> = ({ loading, orders, pageCount, totalCount }) => {
-  // TODO: 로딩, 페이지 카운트, 토탈카운트
-  return (
-    <Wrapper>
-      {orders.map(({ createdAt, title, thumbnail, price, count, status }) => (
-        <MyOrder
-          key={title}
-          createdAt={createdAt}
-          title={title}
-          thumbnail={thumbnail}
-          price={price}
-          count={count}
-          status={status}
-        />
-      ))}
-    </Wrapper>
+const Empty = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 80px;
+  font-family: ${props => props.theme?.fontEuljiro10};
+  color: ${props => props.theme?.colorLine};
+  font-size: 80px;
+`;
+
+const MyOrderList: FC<MyOrderListProps> = ({ loading, orders, totalCount }) => {
+  const inner = totalCount ? (
+    orders.map(({ createdAt, title, thumbnail, price, count, status }) => (
+      <MyOrder
+        key={title}
+        createdAt={createdAt}
+        title={title}
+        thumbnail={thumbnail}
+        price={price}
+        count={count}
+        status={status}
+      />
+    ))
+  ) : (
+    <Empty>
+      <div>텅</div>
+    </Empty>
   );
+
+  return <Wrapper>{loading ? <Loader color="brown" size="100px" /> : inner}</Wrapper>;
 };
 
 export default MyOrderList;

--- a/client/src/components/my/my-order.tsx
+++ b/client/src/components/my/my-order.tsx
@@ -1,15 +1,7 @@
 import styled from 'lib/woowahan-components';
 import React, { FC } from 'react';
+import { IOrder } from 'types/order';
 import { formatPrice } from 'utils';
-
-interface MyOrderProps {
-  createdAt: string;
-  itemTitle: string;
-  thumbnail: string;
-  price: string;
-  count: number;
-  status: string;
-}
 
 const Wrapper = styled.div`
   border-bottom: 1px solid ${props => props.theme?.colorLineLight};
@@ -64,7 +56,7 @@ const Wrapper = styled.div`
   }
 `;
 
-const MyOrder: FC<MyOrderProps> = ({ createdAt, itemTitle, thumbnail, price, count, status }) => {
+const MyOrder: FC<IOrder> = ({ createdAt, title, thumbnail, price, count, status }) => {
   return (
     <Wrapper>
       <div>{createdAt}</div>
@@ -72,7 +64,7 @@ const MyOrder: FC<MyOrderProps> = ({ createdAt, itemTitle, thumbnail, price, cou
         <div>
           <img src={thumbnail} alt="썸네일" />
         </div>
-        <div>{itemTitle}</div>
+        <div>{title}</div>
       </div>
       <div>
         {formatPrice(price)}원 / {count}개

--- a/client/src/containers/my-order-list-container.tsx
+++ b/client/src/containers/my-order-list-container.tsx
@@ -4,13 +4,14 @@ import MyBar from 'components/my/my-bar';
 import MyOrderList from 'components/my/my-order-list';
 import MyStatusBar from 'components/my/my-status-bar';
 import { useHistory } from 'lib/router';
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from 'store';
 import { getOrders } from 'store/order';
 import { getLastMonth, getLastThreeMonth, getLastWeek, getToday } from 'utils/date';
 
 const MyOrderListContainer: FC = () => {
+  const today = getToday();
   const [prevDate, setPrevDate] = useState('');
   const [currentDate, setCurrentDate] = useState('');
   const [select, setSelect] = useState<undefined | number>(undefined);
@@ -31,38 +32,37 @@ const MyOrderListContainer: FC = () => {
 
   useEffect(() => {
     if (prevDate && currentDate) dispatch({ type: getOrders.type, payload: { pageId, prevDate, currentDate } });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch, pageId]);
+  }, [dispatch, pageId, prevDate, currentDate]);
 
   useEffect(() => {
     if (!userLoading && !user) history.push('/');
   }, [userLoading, user, history]);
 
-  const today = getToday();
-  const onClickToday = () => {
+  const onClickToday = useCallback(() => {
     setPrevDate(today);
     setCurrentDate(today);
     setSelect(0);
-  };
-  const onClickThisWeek = () => {
+  }, [today]);
+  const onClickThisWeek = useCallback(() => {
     setPrevDate(getLastWeek());
     setCurrentDate(today);
     setSelect(1);
-  };
-  const onClickThisMonth = () => {
+  }, [today]);
+  const onClickThisMonth = useCallback(() => {
     setPrevDate(getLastMonth());
     setCurrentDate(today);
     setSelect(2);
-  };
-  const onClickThreeMonth = () => {
+  }, [today]);
+  const onClickThreeMonth = useCallback(() => {
     setPrevDate(getLastThreeMonth());
     setCurrentDate(today);
     setSelect(3);
-  };
-  const onSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    dispatch({ type: getOrders.type, payload: { pageId: 1, prevDate, currentDate } });
-  };
+  }, [today]);
+
+  useEffect(() => {
+    onClickToday();
+  }, [onClickToday]);
+
   if (userLoading) return null;
   return (
     <>
@@ -78,7 +78,6 @@ const MyOrderListContainer: FC = () => {
         onClickThisMonth={onClickThisMonth}
         onClickThreeMonth={onClickThreeMonth}
         select={select}
-        onSubmit={onSubmit}
       />
       <MyStatusBar data={['주문일자', '상품명', '상품일금액/수량', '주문상태']} />
       <MyOrderList loading={loading} orders={orders} totalCount={totalCount} />

--- a/client/src/containers/my-order-list-container.tsx
+++ b/client/src/containers/my-order-list-container.tsx
@@ -2,13 +2,40 @@ import InquiryPeriod from 'components/my/inquiry-period';
 import MyBar from 'components/my/my-bar';
 import MyOrderList from 'components/my/my-order-list';
 import MyStatusBar from 'components/my/my-status-bar';
-import React, { FC, useState } from 'react';
+import { useHistory } from 'lib/router';
+import React, { FC, useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from 'store';
+import { getOrders } from 'store/order';
 import { getLastMonth, getLastThreeMonth, getLastWeek, getToday } from 'utils/date';
 
 const MyOrderListContainer: FC = () => {
   const [prevDate, setPrevDate] = useState('');
   const [currentDate, setCurrentDate] = useState('');
   const [select, setSelect] = useState<undefined | number>(undefined);
+  const history = useHistory();
+  const dispatch = useDispatch();
+
+  const { loading, user, orders, pageCount, totalCount, userLoading } = useSelector(
+    ({ auth, loading, order }: RootState) => ({
+      loading: loading['order/getListOrder'],
+      user: auth.user.userId,
+      orders: order.list.orders,
+      pageCount: order.list.pageCount,
+      totalCount: order.list.totalCount,
+      userLoading: loading['auth/getUser'],
+    }),
+  );
+
+  useEffect(() => {
+    // TODO: 페이지네이션 리베이스 받고 수정
+    dispatch({ type: getOrders.type, payload: { pageId: 1, prevDate: getLastThreeMonth(), currentDate: getToday() } });
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (!userLoading && !user) history.push('/');
+  }, [userLoading, user, history]);
+
   const today = getToday();
   const onClickToday = () => {
     setPrevDate(today);
@@ -32,8 +59,11 @@ const MyOrderListContainer: FC = () => {
   };
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: dispatch prevDate, currentDate
+    // TODO: 페이지네이션 리베이스 받고 수정
+    dispatch({ type: getOrders.type, payload: { pageId: 1, prevDate, currentDate } });
   };
+
+  if (userLoading) return null;
   return (
     <>
       <MyBar />
@@ -51,7 +81,7 @@ const MyOrderListContainer: FC = () => {
         onSubmit={onSubmit}
       />
       <MyStatusBar data={['주문일자', '상품명', '상품일금액/수량', '주문상태']} />
-      <MyOrderList />
+      <MyOrderList loading={loading} orders={orders} pageCount={pageCount} totalCount={totalCount} />
     </>
   );
 };

--- a/client/src/containers/my-order-list-container.tsx
+++ b/client/src/containers/my-order-list-container.tsx
@@ -30,7 +30,7 @@ const MyOrderListContainer: FC = () => {
   );
 
   useEffect(() => {
-    dispatch({ type: getOrders.type, payload: { pageId, prevDate, currentDate } });
+    if (prevDate && currentDate) dispatch({ type: getOrders.type, payload: { pageId, prevDate, currentDate } });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, pageId]);
 

--- a/client/src/containers/my-order-list-container.tsx
+++ b/client/src/containers/my-order-list-container.tsx
@@ -1,3 +1,4 @@
+import Pagination from 'components/item/pagination';
 import InquiryPeriod from 'components/my/inquiry-period';
 import MyBar from 'components/my/my-bar';
 import MyOrderList from 'components/my/my-order-list';
@@ -15,6 +16,7 @@ const MyOrderListContainer: FC = () => {
   const [select, setSelect] = useState<undefined | number>(undefined);
   const history = useHistory();
   const dispatch = useDispatch();
+  const [pageId, setPageId] = useState(1);
 
   const { loading, user, orders, pageCount, totalCount, userLoading } = useSelector(
     ({ auth, loading, order }: RootState) => ({
@@ -28,9 +30,9 @@ const MyOrderListContainer: FC = () => {
   );
 
   useEffect(() => {
-    // TODO: 페이지네이션 리베이스 받고 수정
-    dispatch({ type: getOrders.type, payload: { pageId: 1, prevDate: getLastThreeMonth(), currentDate: getToday() } });
-  }, [dispatch]);
+    dispatch({ type: getOrders.type, payload: { pageId, prevDate, currentDate } });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, pageId]);
 
   useEffect(() => {
     if (!userLoading && !user) history.push('/');
@@ -59,10 +61,8 @@ const MyOrderListContainer: FC = () => {
   };
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: 페이지네이션 리베이스 받고 수정
     dispatch({ type: getOrders.type, payload: { pageId: 1, prevDate, currentDate } });
   };
-
   if (userLoading) return null;
   return (
     <>
@@ -81,7 +81,8 @@ const MyOrderListContainer: FC = () => {
         onSubmit={onSubmit}
       />
       <MyStatusBar data={['주문일자', '상품명', '상품일금액/수량', '주문상태']} />
-      <MyOrderList loading={loading} orders={orders} pageCount={pageCount} totalCount={totalCount} />
+      <MyOrderList loading={loading} orders={orders} totalCount={totalCount} />
+      <Pagination pageCount={pageCount} activePage={pageId} setActivePage={setPageId} />
     </>
   );
 };

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -4,19 +4,21 @@ import { authReducer, authSaga } from './auth';
 import { itemReducer, itemSaga } from './item';
 import { loadingReducer } from './loading';
 import { categoryReducer, categorySaga } from './category';
+import { orderReducer, orderSaga } from './order';
 
 const rootReducer = combineReducers({
   auth: authReducer,
   loading: loadingReducer,
   item: itemReducer,
   category: categoryReducer,
+  order: orderReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;
 
 export function* rootSaga(): Generator {
   try {
-    yield all([authSaga(), itemSaga(), categorySaga()]);
+    yield all([authSaga(), itemSaga(), categorySaga(), orderSaga()]);
   } catch (e) {
     throw new Error(e);
   }

--- a/client/src/store/loading.ts
+++ b/client/src/store/loading.ts
@@ -8,6 +8,7 @@ const loadingSlice = createSlice({
     'auth/getSignup': false,
     'item/getMainItem': false,
     'item/getListItem': false,
+    'order/getListOrder': false,
   },
   reducers: {
     startLoading: (state, action) => ({ ...state, [action.payload]: true }),

--- a/client/src/store/order.ts
+++ b/client/src/store/order.ts
@@ -21,7 +21,7 @@ const initialState: StateProps = {
 };
 
 const orderSlice = createSlice({
-  name: 'item',
+  name: 'order',
   initialState,
   reducers: {
     getOrders: state => state,

--- a/client/src/store/order.ts
+++ b/client/src/store/order.ts
@@ -1,0 +1,65 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { put, call, takeLatest } from 'redux-saga/effects';
+import * as orderAPI from 'utils/api/order';
+import axios, { AxiosResponse } from 'axios';
+import { IError } from 'types/error';
+import { IOrderList, IOrderState } from 'types/order';
+import { finishLoading, startLoading } from './loading';
+
+interface StateProps {
+  list: IOrderList;
+  error: null | string;
+}
+
+const initialState: StateProps = {
+  list: {
+    orders: [],
+    pageCount: 0,
+    totalCount: 0,
+  },
+  error: null,
+};
+
+const orderSlice = createSlice({
+  name: 'item',
+  initialState,
+  reducers: {
+    getOrders: state => state,
+    getOrdersSuccess: (state, action: PayloadAction<IOrderList>) => {
+      state.list = action.payload;
+      return state;
+    },
+    getOrdersFail: (state, action: PayloadAction<string>) => {
+      state.error = action.payload;
+      return state;
+    },
+  },
+});
+
+const { actions, reducer: orderReducer } = orderSlice;
+const { getOrders, getOrdersSuccess, getOrdersFail } = actions;
+export { orderReducer, getOrders };
+
+function* getOrdersSaga(action: PayloadAction): Generator {
+  try {
+    yield put(startLoading(getOrders));
+    const { data } = (yield call(
+      orderAPI.getOrderList,
+      action.payload as unknown as IOrderState,
+    )) as AxiosResponse<IOrderList>;
+    yield put({ type: getOrdersSuccess, payload: data });
+  } catch (e) {
+    if (axios.isAxiosError(e)) {
+      const { errorMessage } = e.response?.data as IError;
+      yield put({ type: getOrdersFail, payload: errorMessage });
+    } else {
+      throw new Error(e);
+    }
+  } finally {
+    yield put(finishLoading(getOrders));
+  }
+}
+
+export function* orderSaga(): Generator {
+  yield takeLatest(getOrders, getOrdersSaga);
+}

--- a/client/src/types/order.ts
+++ b/client/src/types/order.ts
@@ -1,0 +1,17 @@
+export interface IOrder {
+  createdAt: string;
+  thumbnail: string;
+  title: string;
+  status: string;
+  price: number;
+  count: number;
+}
+
+export interface IOrderList {
+  orders: IOrder[];
+  totalCount: number;
+  pageCount: number;
+}
+export interface IOrderState {
+  pageId?: number;
+}

--- a/client/src/types/order.ts
+++ b/client/src/types/order.ts
@@ -12,6 +12,9 @@ export interface IOrderList {
   totalCount: number;
   pageCount: number;
 }
+
 export interface IOrderState {
   pageId?: number;
+  prevDate: string;
+  currentDate: string;
 }

--- a/client/src/utils/api/order.ts
+++ b/client/src/utils/api/order.ts
@@ -3,5 +3,5 @@ import { IOrderList, IOrderState } from 'types/order';
 import client from './client';
 
 export const getOrderList = ({ pageId, prevDate, currentDate }: IOrderState): Promise<AxiosResponse> => {
-  return client.post<IOrderList>(`/api/orders?pageId=${pageId || 1}`, { prevDate, currentDate });
+  return client.get<IOrderList>(`/api/orders?pageId=${pageId || 1}&prevDate=${prevDate}&currentDate=${currentDate}`);
 };

--- a/client/src/utils/api/order.ts
+++ b/client/src/utils/api/order.ts
@@ -1,0 +1,7 @@
+import { AxiosResponse } from 'axios';
+import { IOrderList, IOrderState } from 'types/order';
+import client from './client';
+
+export const getOrderList = ({ pageId }: IOrderState): Promise<AxiosResponse> => {
+  return client.get<IOrderList>(`/api/orders?pageId=${pageId || 1}`);
+};

--- a/client/src/utils/api/order.ts
+++ b/client/src/utils/api/order.ts
@@ -2,6 +2,6 @@ import { AxiosResponse } from 'axios';
 import { IOrderList, IOrderState } from 'types/order';
 import client from './client';
 
-export const getOrderList = ({ pageId }: IOrderState): Promise<AxiosResponse> => {
-  return client.get<IOrderList>(`/api/orders?pageId=${pageId || 1}`);
+export const getOrderList = ({ pageId, prevDate, currentDate }: IOrderState): Promise<AxiosResponse> => {
+  return client.post<IOrderList>(`/api/orders?pageId=${pageId || 1}`, { prevDate, currentDate });
 };


### PR DESCRIPTION
<!--
======== Pull Request 자가 체크 리스트 ========
1. 작업 내용에 대해 lint 체크를 완료하였다.
2. 주석 및 불필요한 콘솔 로그를 지웠다.
3. 오타를 확인했다.
4. 버그가 없는지 충분히 테스트해보았다.
5. (프론트엔드) UI에서 기획과 다른 부분은 없는지 확인했다.
-->

## 개요 <!-- 필수 -->

주문내역 페이지 프론트 api 연동 

## 이슈 번호 <!-- 필수 -->

resolve #105 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->

## 참고사항

- 주문하기가 아직 안되서 눈으로 확인하기가 조금 힘듬.
- 그냥 로컬에 직접 넣어서 테스트해봄
- 린트하나 머가 뜰텐데 제가 작성한거 아니에요 아까 기덕님이 그거 그냥 두라고 하셔서 냅두겠습니다

## 추가 구현 필요사항

## 스크린샷 <!-- 클라이언트 작업의 경우 필수 -->
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/57904979/130484299-f9f433fd-c8f8-405b-b215-8dc97a82a193.gif)


