### PR TITLE
Feature/#114 E10-S1 장바구니 페이지

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import {
   SIGNUP_URL,
   ORDER_LIST_URL,
   PAYMENT_URL,
+  CART_URL,
 } from 'constants/urls';
 
 import {
@@ -22,6 +23,7 @@ import {
   ItemDetailPage,
   MyOrderListPage,
   OrderPage,
+  CartPage,
 } from 'pages';
 import Theme from './styles/theme';
 
@@ -38,6 +40,7 @@ const App: React.FC = () => {
           <Route exact path={PAYMENT_URL} component={OrderPage} />
           <Route exact path={AUTH_URL} component={AuthPage} />
           <Route exact path={ORDER_LIST_URL} component={MyOrderListPage} />
+          <Route exact path={CART_URL} component={CartPage} />
           <Route path="" component={NotFoundPage} />
         </Switch>
       </BrowserRouter>

--- a/client/src/components/cart/index.tsx
+++ b/client/src/components/cart/index.tsx
@@ -1,0 +1,207 @@
+import React, { useState, useCallback, Fragment, FC } from 'react';
+import styled from 'lib/woowahan-components';
+import { useHistory } from 'lib/router';
+
+import { PAYMENT_URL } from 'constants/urls';
+
+import TextButton from 'components/common/text-button';
+import PriceCalculator from 'components/common/price-calculator';
+import { TableSection, CartItem } from './table-section';
+
+const Empty = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 80px;
+  font-family: ${props => props.theme?.fontEuljiro10};
+  color: ${props => props.theme?.colorLine};
+  font-size: 80px;
+`;
+
+const Title = styled.h2`
+  width: 100%;
+  font-size: 28px;
+  font-weight: ${({ theme }) => theme?.weightBold};
+  padding-bottom: 30px;
+  border-bottom: 1px solid ${({ theme }) => theme?.colorLineLight};
+  margin-bottom: 24px;
+`;
+
+const ContinueLink = styled.div`
+  cursor: pointer;
+  padding-top: 20px;
+  font-size: 12px;
+  color: ${({ theme }) => theme?.colorSoftBlack};
+`;
+
+const ButtonDiv = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 50px;
+`;
+
+const OrderButtonDiv = styled.div``;
+
+const cartValidator = (): boolean => {
+  const data = localStorage.getItem('cart') as string;
+  if (data !== null) {
+    const cartData = data.split(',');
+    try {
+      if (cartData.length !== 0 && cartData.length % 5 === 0) {
+        cartData.forEach((value, idx) => {
+          const valueSplit = value.split('.');
+
+          switch (idx % 5) {
+            case 0:
+              if (Number.isNaN(Number(value))) {
+                throw new Error('올바르지 않은 아이템 아이디');
+              }
+              break;
+            case 1:
+              if (
+                !(
+                  value.indexOf('https://storage.googleapis.com/bmart-5482b.appspot.com/') >= 0 &&
+                  (valueSplit[valueSplit.length - 1] === 'jpg' || valueSplit[valueSplit.length - 1] === 'png')
+                )
+              ) {
+                throw new Error('올바르지 않은 썸네일 주소');
+              }
+              break;
+            case 2:
+              break;
+            case 3:
+              if (Number.isNaN(Number(value))) {
+                throw new Error('올바르지 않은 갯수');
+              }
+              break;
+            case 4:
+              if (Number.isNaN(Number(value))) {
+                throw new Error('올바르지 않은 가격');
+              }
+              break;
+            default:
+              break;
+          }
+        });
+      } else {
+        throw new Error('카트 데이터 오류');
+      }
+
+      return true;
+    } catch (error) {
+      localStorage.removeItem('cart');
+      return false;
+    }
+  } else {
+    return false;
+  }
+};
+
+const cartGenerator = (): CartItem[] => {
+  if (cartValidator()) {
+    const cartItems: CartItem[] = [];
+    const data = localStorage.getItem('cart') as string;
+    const cartData = data.split(',');
+    cartData.forEach((value, idx) => {
+      const num = Math.floor(idx / 5);
+      switch (idx % 5) {
+        case 0:
+          cartItems.push({ id: value, thumbnail: '', title: '', count: 0, price: 0 });
+          break;
+        case 1:
+          cartItems[num].thumbnail = value;
+          break;
+        case 2:
+          cartItems[num].title = value;
+          break;
+        case 3:
+          cartItems[num].count = Number(value);
+          break;
+        case 4:
+          cartItems[num].price = Number(value);
+          break;
+        default:
+          break;
+      }
+    });
+    return cartItems;
+  }
+  return [];
+};
+
+const Cart: FC = () => {
+  const [prices, setPrices] = useState([0]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [cartItems, setCartItems] = useState(cartGenerator());
+  const [checkedItems, setCheckedItems] = useState(new Set<number>());
+  const history = useHistory();
+  const onClick = useCallback(() => history.goBack(), [history]);
+
+  const deleteSelectCartItem = () => {
+    const data = localStorage.getItem('select') as string;
+    const select = data.split(',');
+    let cartItems = cartGenerator();
+    cartItems = cartItems.filter((item, index) => select.indexOf(index.toString()) < 0);
+    let cartItemsString = '';
+    cartItems.forEach(item => {
+      cartItemsString += `${item.id},${item.thumbnail},${item.title},${item.count},${item.price},`;
+    });
+    cartItemsString = cartItemsString.slice(0, cartItemsString.length - 1);
+    localStorage.setItem('cart', cartItemsString);
+    localStorage.removeItem('select');
+    setCartItems(cartGenerator());
+    setPrices([0]);
+    setTotalCount(0);
+    setCheckedItems(new Set<number>());
+  };
+
+  const orderCartItem = (isAll: boolean) => () => {
+    let selectCartItems: CartItem[] = [];
+    if (isAll) {
+      selectCartItems = cartItems;
+    } else {
+      Array.from(checkedItems).forEach(index => selectCartItems.push(cartItems[index]));
+    }
+    let selectCartItemsString = '';
+    selectCartItems.forEach(item => {
+      selectCartItemsString += `${item.id}-${item.count},`;
+    });
+    selectCartItemsString = selectCartItemsString.slice(0, selectCartItemsString.length - 1);
+
+    if (selectCartItemsString !== '') {
+      sessionStorage.setItem('order', selectCartItemsString);
+      history.push(PAYMENT_URL);
+    }
+  };
+
+  return (
+    <>
+      <Title>장바구니</Title>
+      {cartValidator() ? (
+        <>
+          <TableSection
+            cartItems={cartItems}
+            checkedItems={checkedItems}
+            setPrices={setPrices}
+            setTotalCount={setTotalCount}
+            setCheckedItems={setCheckedItems}
+          />
+          <ContinueLink onClick={onClick}>{'<'} 쇼핑 계속하기</ContinueLink>
+          <PriceCalculator prices={prices} totalCount={totalCount} />
+          <ButtonDiv>
+            <TextButton title="선택 상품 삭제" type="submit" styleType="white" onClick={deleteSelectCartItem} />
+            <OrderButtonDiv>
+              <TextButton title="선택 상품 주문" type="submit" styleType="white" onClick={orderCartItem(false)} />
+              <TextButton title="전체 상품 주문" type="submit" styleType="black" onClick={orderCartItem(true)} />
+            </OrderButtonDiv>
+          </ButtonDiv>
+        </>
+      ) : (
+        <Empty>
+          <div>텅</div>
+        </Empty>
+      )}
+    </>
+  );
+};
+
+export default Cart;

--- a/client/src/components/cart/table-section.tsx
+++ b/client/src/components/cart/table-section.tsx
@@ -6,7 +6,6 @@ import { formatPrice } from 'utils';
 import Table from 'components/common/table';
 import { CheckBox } from 'components';
 
-
 interface TableSectionProps {
   cartItems: CartItem[];
   checkedItems: Set<number>;

--- a/client/src/components/cart/table-section.tsx
+++ b/client/src/components/cart/table-section.tsx
@@ -1,0 +1,142 @@
+import React, { Fragment, FC, useState } from 'react';
+import styled from 'lib/woowahan-components';
+
+import { formatPrice } from 'utils';
+
+import Table from 'components/common/table';
+import { CheckBox } from 'components';
+
+
+interface TableSectionProps {
+  cartItems: CartItem[];
+  checkedItems: Set<number>;
+  setPrices: React.Dispatch<React.SetStateAction<number[]>>;
+  setTotalCount: React.Dispatch<React.SetStateAction<number>>;
+  setCheckedItems: React.Dispatch<React.SetStateAction<Set<number>>>;
+}
+
+interface CartItem {
+  id: string;
+  thumbnail: string;
+  title: string;
+  count: number;
+  price: number;
+}
+
+const TableRowTitle = styled.div`
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  font-weight: ${({ theme }) => theme?.weightMid};
+
+  img {
+    width: 42px;
+    height: auto;
+    margin-right: 8px;
+  }
+
+  ${({ theme }) => theme?.mobile} {
+    img {
+      display: none;
+    }
+  }
+`;
+const TableRowText = styled.div`
+  text-align: center;
+`;
+
+const tableHeaders = [
+  { column: '상품/옵션 정보', span: 6 },
+  { column: '수량', span: 1 },
+  { column: '상품금액', span: 1 },
+  { column: '배송비', span: 1 },
+];
+
+const TableSection: FC<TableSectionProps> = ({
+  cartItems,
+  checkedItems,
+  setPrices,
+  setTotalCount,
+  setCheckedItems,
+}) => {
+  const [checkAll, setCheckAll] = useState(false);
+
+  const updatePrice = (set: Set<number>) => {
+    const prices = [] as number[];
+    let totalCount = 0;
+    Array.from(set).forEach(index => {
+      const item = cartItems[Number(index)];
+      prices.push(item.price * item.count);
+      totalCount += item.count;
+    });
+    if (prices.length === 0) {
+      prices.push(0);
+    }
+    setPrices(prices);
+    setTotalCount(totalCount);
+  };
+
+  const checkedItemHandler = (id: number) => () => {
+    const checkedSet = new Set<number>(checkedItems);
+    if (checkedSet.has(id)) {
+      checkedSet.delete(id);
+      setCheckedItems(checkedSet);
+    } else {
+      checkedSet.add(id);
+      setCheckedItems(checkedSet);
+    }
+
+    if (cartItems.length === checkedSet.size) {
+      setCheckAll(true);
+    } else {
+      setCheckAll(false);
+    }
+    updatePrice(checkedSet);
+    localStorage.setItem('select', Array.from(checkedSet).join(','));
+  };
+
+  const checkAllHandler = () => {
+    if (checkAll) {
+      setCheckAll(false);
+      setCheckedItems(new Set<number>());
+      localStorage.setItem('select', '');
+    } else {
+      setCheckAll(true);
+      const checkedSet = new Set<number>();
+      cartItems.forEach((item, index) => checkedSet.add(index));
+      setCheckedItems(checkedSet);
+      updatePrice(checkedSet);
+      localStorage.setItem('select', Array.from(checkedSet).join(','));
+    }
+  };
+
+  return (
+    <Table
+      headers={[
+        {
+          column: <CheckBox id="all" text="" onChange={checkAllHandler} check={checkAll} />,
+          span: 1,
+        },
+        ...tableHeaders,
+      ]}
+    >
+      {cartItems.map((item, idx) => {
+        const { id, title, thumbnail, count, price } = item;
+        return (
+          <Fragment key={id.toString() + idx.toString()}>
+            <TableRowTitle>
+              <CheckBox id={idx.toString()} text="" onChange={checkedItemHandler(idx)} check={checkedItems.has(idx)} />
+              <img src={thumbnail} alt={title} />
+              {title}
+            </TableRowTitle>
+            <TableRowText>{count}개</TableRowText>
+            <TableRowText>{formatPrice(price)}원</TableRowText>
+            <TableRowText>공짜!</TableRowText>
+          </Fragment>
+        );
+      })}
+    </Table>
+  );
+};
+
+export { TableSection, CartItem };

--- a/client/src/components/common/text-button.tsx
+++ b/client/src/components/common/text-button.tsx
@@ -10,7 +10,7 @@ interface ButtonProps {
   title: string;
   styleType: StyleType;
   size?: Size;
-  onClick?: () => void;
+  onClick?: ((count: number) => void) | (() => void);
   disabled?: boolean;
   isLoading?: boolean;
 }

--- a/client/src/components/form/check-box.tsx
+++ b/client/src/components/form/check-box.tsx
@@ -5,6 +5,7 @@ interface CheckBoxProps {
   id: string;
   text: string;
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  check?: boolean;
 }
 
 const Label = styled.label`
@@ -18,19 +19,19 @@ const Label = styled.label`
   &:hover .checkmark {
     background-color: ${props => props.theme?.colorPointBeigeLight};
   }
-`;
 
-const CheckBoxInput = styled.input`
-  opacity: 0;
-  height: 0;
-  width: 0;
+  input[type='checkbox'] {
+    opacity: 0;
+    height: 0;
+    width: 0;
 
-  &:checked ~ .checkmark {
-    background-color: ${props => props.theme?.colorLine};
-  }
+    &:checked ~ .checkmark {
+      background-color: ${props => props.theme?.colorLine};
+    }
 
-  &:checked ~ .checkmark:after {
-    display: block;
+    &:checked ~ .checkmark:after {
+      display: block;
+    }
   }
 `;
 
@@ -57,10 +58,10 @@ const CheckMark = styled.span`
   }
 `;
 
-const CheckBox: FC<CheckBoxProps> = ({ id, text, onChange }) => {
+const CheckBox: FC<CheckBoxProps> = ({ id, text, onChange, check }) => {
   return (
     <Label htmlFor={id}>
-      <CheckBoxInput type="checkbox" id={id} onChange={onChange} />
+      <input type="checkbox" id={id} checked={check} onChange={onChange} />
       <CheckMark className="checkmark" />
       {text}
     </Label>

--- a/client/src/components/item-detail/index.tsx
+++ b/client/src/components/item-detail/index.tsx
@@ -11,7 +11,7 @@ export interface ItemDetailProps {
   isLike: boolean;
   isSoldOut: boolean;
   reviewCount: number;
-  onSubmitCart: () => void;
+  onSubmitCart: (count: number) => void;
   onBuy: () => void;
 }
 

--- a/client/src/components/item-detail/info-section.tsx
+++ b/client/src/components/item-detail/info-section.tsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect, FC } from 'react';
+import { Link } from 'lib/router';
 import styled from 'lib/woowahan-components';
+
 import useWindowSize from 'hooks/use-window-size';
 
 import starsTitle from 'assets/icons/stars_title.png';
 
 import { formatPrice } from 'utils';
+import { CART_URL } from 'constants/urls';
 
 import TextButton from 'components/common/text-button';
 import ImageViewer from 'components/image-viewer';
@@ -16,7 +19,7 @@ export interface InfoSectionProps {
   price: number;
   isLike: boolean;
   isSoldOut: boolean;
-  onSubmitCart: () => void;
+  onSubmitCart: (count: number) => void;
   onBuy: () => void;
 }
 
@@ -203,7 +206,15 @@ const InfoSection: FC<InfoSectionProps> = ({ thumbnail, title, price, isSoldOut,
               <TextButton title="다 팔렸읍니다" type="button" styleType="black" disabled />
             ) : (
               <>
-                <TextButton title="장바구니" type="button" styleType="white" onClick={onSubmitCart} />
+                <Link to={CART_URL}>
+                  <TextButton
+                    title="장바구니"
+                    type="button"
+                    styleType="white"
+                    onClick={() => onSubmitCart(totalPrice / price)}
+                  />
+                </Link>
+
                 <TextButton title="바로구매" type="button" styleType="black" onClick={onBuy} />
               </>
             )}

--- a/client/src/containers/item-detail-container.tsx
+++ b/client/src/containers/item-detail-container.tsx
@@ -26,8 +26,13 @@ const MainItemContainer: FC = () => {
     dispatch({ type: getItem.type, payload: { id } });
   }, [id, dispatch]);
 
-  const onSubmitCart = () => {
-    // TODO: 장바구니 추가
+  const onSubmitCart = (count: number) => {
+    if (!localStorage.getItem('cart')) {
+      localStorage.setItem('cart', `${id},${thumbnail},${title},${count},${price}`);
+    } else {
+      const data = localStorage.getItem('cart') as string;
+      localStorage.setItem('cart', `${data},${id},${thumbnail},${title},${count},${price}`);
+    }
   };
 
   const onBuy = () => {

--- a/client/src/pages/cart-page.tsx
+++ b/client/src/pages/cart-page.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from 'react';
+import useWindowSize from 'hooks/use-window-size';
+import NavbarContainer from 'containers/navbar-container';
+import { Layout } from 'components';
+import Cart from 'components/cart';
+
+const CartPage = (): ReactElement => {
+  const { width } = useWindowSize();
+  const isMobile = width <= 480;
+
+  return (
+    <>
+      <NavbarContainer isMobile={isMobile} />
+      <Layout isMobile={isMobile}>
+        <Cart />
+      </Layout>
+    </>
+  );
+};
+
+export default CartPage;

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -7,3 +7,4 @@ export { default as AuthPage } from './auth-page';
 export { default as ItemListPage } from './item-list-page';
 export { default as MyOrderListPage } from './my-order-list-page';
 export { default as OrderPage } from './order-page';
+export { default as CartPage } from './cart-page';


### PR DESCRIPTION
<!--
======== Pull Request 자가 체크 리스트 ========
1. 작업 내용에 대해 lint 체크를 완료하였다.
2. 주석 및 불필요한 콘솔 로그를 지웠다.
3. 오타를 확인했다.
4. 버그가 없는지 충분히 테스트해보았다.
5. (프론트엔드) UI에서 기획과 다른 부분은 없는지 확인했다.
-->

## 개요 <!-- 필수 -->
장바구니에 상품을 담고 선택해서 주문할 수 있는 기능을 개발했습니다

## 이슈 번호 <!-- 필수 -->
 - #114 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->
 - 장바구니 페이지가 추가되었습니다
 - 상품 상세 페이지 장바구니 버튼에 상품을 장바구니에 담는 기능을 추가했습니다
 - 체크박스 컴포넌트를 state로 조작할 수 있도록 checked를 추가했습니다
 - 텍스트 버튼 props의 onClick 함수에 number를 인자로 받는 형식을 추가했습니다

## 참고사항
 - 상품 상세 페이지 장바구니 버튼으로 장바구니에 상품을 담을 수 있으며 로컬 스토리지에 저장됩니다
 - 장바구니 주소는 /cart 입니다
 - 주문하기를 누르면 상품 정보가 id-count,id-count ... 형식으로 세션 스토리지에 저장됩니다

## 추가 구현 필요사항

 - 테이블 섹션, 텍스트 버튼 수정 후 스타일 작업

## 스크린샷 <!-- 클라이언트 작업의 경우 필수 -->
![image](https://user-images.githubusercontent.com/86910140/130829991-9f874560-fd43-4949-96b6-4885a3694ec9.png)
