### PR TITLE
Fix/#185 페이지네이션 및 정렬을 url query 방식으로 변경

### DIFF
--- a/client/src/components/common/pagination.tsx
+++ b/client/src/components/common/pagination.tsx
@@ -59,7 +59,7 @@ const Pagination: FC<PaginationProps> = ({ className = '', pageCount, showCnt = 
   const handleClickPage = useCallback(page => goPage(page), [goPage]);
 
   useEffect(() => {
-    const { pageId } = query;
+    const { pageId = 1 } = query;
     const temp = Math.floor(Number(pageId) / showCnt);
     setStartPage((Number(pageId) % showCnt === 0 ? temp - 1 : temp) * showCnt + 1);
   }, [query, showCnt]);
@@ -71,7 +71,7 @@ const Pagination: FC<PaginationProps> = ({ className = '', pageCount, showCnt = 
         <Button
           type="button"
           key={page}
-          className={Number(query.pageId) === page && 'active'}
+          className={(Number(query.pageId) || 1) === page && 'active'}
           onClick={() => handleClickPage(page)}
         >
           {page}

--- a/client/src/components/common/pagination.tsx
+++ b/client/src/components/common/pagination.tsx
@@ -36,7 +36,6 @@ const Pagination: FC<PaginationProps> = ({ className = '', pageCount, showCnt = 
   const history = useHistory();
   const query = useQuery();
   const [startPage, setStartPage] = useState(1);
-  const [activePage, setActivePage] = useState(1);
 
   const goPage = useCallback(
     (pageId: number) => {
@@ -49,29 +48,20 @@ const Pagination: FC<PaginationProps> = ({ className = '', pageCount, showCnt = 
 
   const goNextPage = useCallback(() => {
     setStartPage(startPage + showCnt);
-    setActivePage(startPage + showCnt);
     goPage(startPage + showCnt);
   }, [showCnt, startPage, goPage]);
 
   const goPrevPage = useCallback(() => {
     setStartPage(startPage - showCnt);
-    setActivePage(startPage - showCnt);
     goPage(startPage - showCnt);
   }, [showCnt, startPage, goPage]);
 
-  const handleClickPage = useCallback(
-    page => {
-      setActivePage(page);
-      goPage(page);
-    },
-    [goPage],
-  );
+  const handleClickPage = useCallback(page => goPage(page), [goPage]);
 
   useEffect(() => {
     const { pageId } = query;
     const temp = Math.floor(Number(pageId) / showCnt);
     setStartPage((Number(pageId) % showCnt === 0 ? temp - 1 : temp) * showCnt + 1);
-    setActivePage(Number(pageId));
   }, [query, showCnt]);
 
   const renderPage = () => {
@@ -81,7 +71,7 @@ const Pagination: FC<PaginationProps> = ({ className = '', pageCount, showCnt = 
         <Button
           type="button"
           key={page}
-          className={activePage === page && 'active'}
+          className={Number(query.pageId) === page && 'active'}
           onClick={() => handleClickPage(page)}
         >
           {page}

--- a/client/src/components/common/pagination.tsx
+++ b/client/src/components/common/pagination.tsx
@@ -1,12 +1,11 @@
-import React, { FC, useCallback, useState, Dispatch, SetStateAction } from 'react';
+import React, { FC, useCallback, useState, useEffect } from 'react';
 import styled from 'lib/woowahan-components';
+import { useHistory, useQuery } from 'lib/router';
 
 interface PaginationProps {
   className?: string;
   pageCount: number;
   showCnt?: number;
-  activePage: number;
-  setActivePage: Dispatch<SetStateAction<number>>;
 }
 
 const Wrapper = styled.div`
@@ -33,25 +32,47 @@ const Button = styled.button`
   }
 `;
 
-const Pagination: FC<PaginationProps> = ({ className = '', pageCount, showCnt = 5, activePage, setActivePage }) => {
+const Pagination: FC<PaginationProps> = ({ className = '', pageCount, showCnt = 5 }) => {
+  const history = useHistory();
+  const query = useQuery();
   const [startPage, setStartPage] = useState(1);
+  const [activePage, setActivePage] = useState(1);
+
+  const goPage = useCallback(
+    (pageId: number) => {
+      const searchParams = new URLSearchParams(window.location.search);
+      searchParams.set('pageId', pageId.toString());
+      history.push(`${window.location.pathname}?${searchParams.toString()}`);
+    },
+    [history],
+  );
 
   const goNextPage = useCallback(() => {
     setStartPage(startPage + showCnt);
     setActivePage(startPage + showCnt);
-  }, [showCnt, startPage, setActivePage]);
+    goPage(startPage + showCnt);
+  }, [showCnt, startPage, goPage]);
 
   const goPrevPage = useCallback(() => {
     setStartPage(startPage - showCnt);
     setActivePage(startPage - showCnt);
-  }, [showCnt, startPage, setActivePage]);
+    goPage(startPage - showCnt);
+  }, [showCnt, startPage, goPage]);
 
   const handleClickPage = useCallback(
     page => {
       setActivePage(page);
+      goPage(page);
     },
-    [setActivePage],
+    [goPage],
   );
+
+  useEffect(() => {
+    const { pageId } = query;
+    const temp = Math.floor(Number(pageId) / showCnt);
+    setStartPage((Number(pageId) % showCnt === 0 ? temp - 1 : temp) * showCnt + 1);
+    setActivePage(Number(pageId));
+  }, [query, showCnt]);
 
   const renderPage = () => {
     const items = [];

--- a/client/src/components/common/pagination.tsx
+++ b/client/src/components/common/pagination.tsx
@@ -41,7 +41,7 @@ const Pagination: FC<PaginationProps> = ({ className = '', pageCount, showCnt = 
     (pageId: number) => {
       const searchParams = new URLSearchParams(window.location.search);
       searchParams.set('pageId', pageId.toString());
-      history.push(`${window.location.pathname}?${searchParams.toString()}`);
+      history.push(`${history.currentPath}?${searchParams.toString()}`);
     },
     [history],
   );

--- a/client/src/components/item-detail/detail.tsx
+++ b/client/src/components/item-detail/detail.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef, Dispatch, SetStateAction } from 'react';
+import React, { FC, useRef } from 'react';
 import styled from 'lib/woowahan-components';
 
 import { IReview } from 'types/review';

--- a/client/src/components/item-detail/detail.tsx
+++ b/client/src/components/item-detail/detail.tsx
@@ -14,8 +14,6 @@ interface DetailProps {
   itemLoading: boolean;
   reviewLoading: boolean;
   pageCount: number;
-  pageId: number;
-  setPageId: Dispatch<SetStateAction<number>>;
 }
 
 const Container = styled.section`
@@ -54,7 +52,7 @@ const DetailImageWrapper = styled.div`
   }
 `;
 
-const Detail: FC<DetailProps> = ({ contents, reviewCount, reviews, reviewLoading, pageCount, pageId, setPageId }) => {
+const Detail: FC<DetailProps> = ({ contents, reviewCount, reviews, reviewLoading, pageCount }) => {
   const detailRef = useRef<HTMLDivElement>(null);
   const detailExecuteScroll = () => {
     if (detailRef.current) detailRef.current.scrollIntoView({ behavior: 'smooth' });
@@ -92,7 +90,7 @@ const Detail: FC<DetailProps> = ({ contents, reviewCount, reviews, reviewLoading
         reviewExecuteScroll={reviewExecuteScroll}
       >
         <ReviewList reviews={reviews} reviewLoading={reviewLoading} />
-        <Pagination className="review-pagination" pageCount={pageCount} activePage={pageId} setActivePage={setPageId} />
+        <Pagination className="review-pagination" pageCount={pageCount} />
       </DetailWrapper>
     </Container>
   );

--- a/client/src/components/item/search-item/filter.tsx
+++ b/client/src/components/item/search-item/filter.tsx
@@ -1,14 +1,11 @@
-import React, { FC, Dispatch, SetStateAction, ReactNode, useCallback } from 'react';
+import React, { FC, ReactNode, useCallback } from 'react';
 import styled from 'lib/woowahan-components';
 
-import { ESortType } from 'types/item';
-
 import { SORT } from 'constants/index';
+import { useHistory, useQuery } from 'lib/router';
 
 interface FilterProps {
   total: number;
-  sortType: ESortType;
-  setSortType: Dispatch<SetStateAction<ESortType>>;
 }
 
 const Wrapper = styled.div`
@@ -58,12 +55,18 @@ const Sort = styled.div`
   }
 `;
 
-const Filter: FC<FilterProps> = ({ total, sortType, setSortType }) => {
+const Filter: FC<FilterProps> = ({ total }) => {
+  const history = useHistory();
+  const query = useQuery();
+
   const handleClickSort = useCallback(
     sortType => {
-      setSortType(sortType);
+      const searchParams = new URLSearchParams(window.location.search);
+      searchParams.set('type', sortType);
+      searchParams.set('pageId', '1');
+      history.push(`${window.location.pathname}?${searchParams.toString()}`);
     },
-    [setSortType],
+    [history],
   );
 
   return (
@@ -75,7 +78,7 @@ const Filter: FC<FilterProps> = ({ total, sortType, setSortType }) => {
             <button
               key={sort.type}
               type="button"
-              className={sortType === sort.type ? 'active' : ''}
+              className={query.type === sort.type ? 'active' : ''}
               onClick={() => handleClickSort(sort.type)}
             >
               {sort.value}

--- a/client/src/components/item/search-item/filter.tsx
+++ b/client/src/components/item/search-item/filter.tsx
@@ -1,8 +1,9 @@
 import React, { FC, ReactNode, useCallback } from 'react';
 import styled from 'lib/woowahan-components';
+import { useHistory, useQuery } from 'lib/router';
 
 import { SORT } from 'constants/index';
-import { useHistory, useQuery } from 'lib/router';
+import { ESortType } from 'types/item';
 
 interface FilterProps {
   total: number;
@@ -78,7 +79,7 @@ const Filter: FC<FilterProps> = ({ total }) => {
             <button
               key={sort.type}
               type="button"
-              className={query.type === sort.type ? 'active' : ''}
+              className={(query.type || ESortType.RECOMMEND) === sort.type ? 'active' : ''}
               onClick={() => handleClickSort(sort.type)}
             >
               {sort.value}

--- a/client/src/components/item/search-item/filter.tsx
+++ b/client/src/components/item/search-item/filter.tsx
@@ -65,7 +65,7 @@ const Filter: FC<FilterProps> = ({ total }) => {
       const searchParams = new URLSearchParams(window.location.search);
       searchParams.set('type', sortType);
       searchParams.set('pageId', '1');
-      history.push(`${window.location.pathname}?${searchParams.toString()}`);
+      history.push(`${history.currentPath}?${searchParams.toString()}`);
     },
     [history],
   );

--- a/client/src/components/item/search-item/search-item-wrapper.tsx
+++ b/client/src/components/item/search-item/search-item-wrapper.tsx
@@ -1,9 +1,9 @@
-import React, { FC, Dispatch, SetStateAction } from 'react';
+import React, { FC } from 'react';
 import styled from 'lib/woowahan-components';
 
 import findIcon from 'assets/icons/find.png';
 
-import { IItem, ESortType } from 'types/item';
+import { IItem } from 'types/item';
 
 import { Pagination } from 'components';
 import ItemList from '../item-list';
@@ -14,8 +14,6 @@ interface SearchItemWrapperProps {
   loading: boolean;
   pageCount: number;
   totalCount: number;
-  sortType: ESortType;
-  setSortType: Dispatch<SetStateAction<ESortType>>;
 }
 
 const Wrapper = styled.div`
@@ -70,17 +68,10 @@ const Empty = styled.div`
   }
 `;
 
-const SearchItemWrapper: FC<SearchItemWrapperProps> = ({
-  items,
-  loading,
-  pageCount,
-  totalCount,
-  sortType,
-  setSortType,
-}) => {
+const SearchItemWrapper: FC<SearchItemWrapperProps> = ({ items, loading, pageCount, totalCount }) => {
   return (
     <Wrapper>
-      <Filter total={totalCount} sortType={sortType} setSortType={setSortType} />
+      <Filter total={totalCount} />
       {loading || totalCount ? (
         <>
           <ItemList items={items} isLoading={loading} />

--- a/client/src/components/item/search-item/search-item-wrapper.tsx
+++ b/client/src/components/item/search-item/search-item-wrapper.tsx
@@ -13,8 +13,6 @@ interface SearchItemWrapperProps {
   items: IItem[];
   loading: boolean;
   pageCount: number;
-  pageId: number;
-  setPageId: Dispatch<SetStateAction<number>>;
   totalCount: number;
   sortType: ESortType;
   setSortType: Dispatch<SetStateAction<ESortType>>;
@@ -76,8 +74,6 @@ const SearchItemWrapper: FC<SearchItemWrapperProps> = ({
   items,
   loading,
   pageCount,
-  pageId,
-  setPageId,
   totalCount,
   sortType,
   setSortType,
@@ -88,7 +84,7 @@ const SearchItemWrapper: FC<SearchItemWrapperProps> = ({
       {loading || totalCount ? (
         <>
           <ItemList items={items} isLoading={loading} />
-          <Pagination pageCount={pageCount} activePage={pageId} setActivePage={setPageId} />
+          <Pagination pageCount={pageCount} />
         </>
       ) : (
         <Empty>

--- a/client/src/components/smart-menu/large-menu.tsx
+++ b/client/src/components/smart-menu/large-menu.tsx
@@ -102,7 +102,7 @@ const LargeMenu: FC<LargeMenuProps> = ({
 }) => {
   const history = useHistory();
   const goCategoryPage = useCallback(
-    (code: string) => () => history.push(`${ITEM_LIST_URL}?categoryId=${code}`),
+    (code: string) => () => history.push(`${ITEM_LIST_URL}?categoryId=${code}&pageId=1`),
     [history],
   );
 
@@ -128,7 +128,7 @@ const LargeMenu: FC<LargeMenuProps> = ({
                   setLargeId(largeId);
                   e.stopPropagation();
                 } else {
-                  history.push(`${ITEM_LIST_URL}?categoryId=${large.code}`);
+                  history.push(`${ITEM_LIST_URL}?categoryId=${large.code}&pageId=1`);
                 }
               }}
               isSelected={selectedLargeId === largeId}

--- a/client/src/components/smart-menu/large-menu.tsx
+++ b/client/src/components/smart-menu/large-menu.tsx
@@ -5,7 +5,6 @@ import { useHistory } from 'lib/router';
 import arrow from 'assets/icons/arrow_forward.svg';
 
 import { IMenu } from 'types/category';
-import { ESortType } from 'types/item';
 
 import { SMART_MENU_BLOCK_DELAY } from 'constants/index';
 import { ITEM_LIST_URL } from 'constants/urls';
@@ -103,7 +102,7 @@ const LargeMenu: FC<LargeMenuProps> = ({
 }) => {
   const history = useHistory();
   const goCategoryPage = useCallback(
-    (code: string) => () => history.push(`${ITEM_LIST_URL}?categoryId=${code}&pageId=1&type=${ESortType.RECOMMEND}`),
+    (code: string) => () => history.push(`${ITEM_LIST_URL}?categoryId=${code}`),
     [history],
   );
 
@@ -129,7 +128,7 @@ const LargeMenu: FC<LargeMenuProps> = ({
                   setLargeId(largeId);
                   e.stopPropagation();
                 } else {
-                  history.push(`${ITEM_LIST_URL}?categoryId=${large.code}&pageId=1&type=${ESortType.RECOMMEND}`);
+                  history.push(`${ITEM_LIST_URL}?categoryId=${large.code}`);
                 }
               }}
               isSelected={selectedLargeId === largeId}

--- a/client/src/components/smart-menu/large-menu.tsx
+++ b/client/src/components/smart-menu/large-menu.tsx
@@ -5,6 +5,7 @@ import { useHistory } from 'lib/router';
 import arrow from 'assets/icons/arrow_forward.svg';
 
 import { IMenu } from 'types/category';
+import { ESortType } from 'types/item';
 
 import { SMART_MENU_BLOCK_DELAY } from 'constants/index';
 import { ITEM_LIST_URL } from 'constants/urls';
@@ -102,7 +103,7 @@ const LargeMenu: FC<LargeMenuProps> = ({
 }) => {
   const history = useHistory();
   const goCategoryPage = useCallback(
-    (code: string) => () => history.push(`${ITEM_LIST_URL}?categoryId=${code}&pageId=1`),
+    (code: string) => () => history.push(`${ITEM_LIST_URL}?categoryId=${code}&pageId=1&type=${ESortType.RECOMMEND}`),
     [history],
   );
 
@@ -128,7 +129,7 @@ const LargeMenu: FC<LargeMenuProps> = ({
                   setLargeId(largeId);
                   e.stopPropagation();
                 } else {
-                  history.push(`${ITEM_LIST_URL}?categoryId=${large.code}&pageId=1`);
+                  history.push(`${ITEM_LIST_URL}?categoryId=${large.code}&pageId=1&type=${ESortType.RECOMMEND}`);
                 }
               }}
               isSelected={selectedLargeId === largeId}

--- a/client/src/components/smart-menu/medium-menu.tsx
+++ b/client/src/components/smart-menu/medium-menu.tsx
@@ -77,7 +77,7 @@ const Image = styled.img`
 const MediumMenu: FC<MediumMenuProps> = ({ menu, selectedLargeId, selectedMediumId, isMobile, setMediumId }) => {
   const history = useHistory();
   const goCategoryPage = useCallback(
-    (code: string) => () => history.push(`${ITEM_LIST_URL}?categoryId=${code}`),
+    (code: string) => () => history.push(`${ITEM_LIST_URL}?categoryId=${code}&pageId=1`),
     [history],
   );
 
@@ -99,7 +99,7 @@ const MediumMenu: FC<MediumMenuProps> = ({ menu, selectedLargeId, selectedMedium
                     setMediumId(mediumId);
                     e.stopPropagation();
                   } else {
-                    history.push(`${ITEM_LIST_URL}?categoryId=${medium.code}`);
+                    history.push(`${ITEM_LIST_URL}?categoryId=${medium.code}&pageId=1`);
                   }
                 }}
                 isSelected={selectedMediumId === mediumId}

--- a/client/src/components/smart-menu/medium-menu.tsx
+++ b/client/src/components/smart-menu/medium-menu.tsx
@@ -5,7 +5,6 @@ import { useHistory } from 'lib/router';
 import arrow from 'assets/icons/arrow_forward.svg';
 
 import { IMenu } from 'types/category';
-import { ESortType } from 'types/item';
 
 import { ITEM_LIST_URL } from 'constants/urls';
 
@@ -78,7 +77,7 @@ const Image = styled.img`
 const MediumMenu: FC<MediumMenuProps> = ({ menu, selectedLargeId, selectedMediumId, isMobile, setMediumId }) => {
   const history = useHistory();
   const goCategoryPage = useCallback(
-    (code: string) => () => history.push(`${ITEM_LIST_URL}?categoryId=${code}&pageId=1&type=${ESortType.RECOMMEND}`),
+    (code: string) => () => history.push(`${ITEM_LIST_URL}?categoryId=${code}`),
     [history],
   );
 
@@ -100,7 +99,7 @@ const MediumMenu: FC<MediumMenuProps> = ({ menu, selectedLargeId, selectedMedium
                     setMediumId(mediumId);
                     e.stopPropagation();
                   } else {
-                    history.push(`${ITEM_LIST_URL}?categoryId=${medium.code}&pageId=1&type=${ESortType.RECOMMEND}`);
+                    history.push(`${ITEM_LIST_URL}?categoryId=${medium.code}`);
                   }
                 }}
                 isSelected={selectedMediumId === mediumId}

--- a/client/src/components/smart-menu/medium-menu.tsx
+++ b/client/src/components/smart-menu/medium-menu.tsx
@@ -5,6 +5,7 @@ import { useHistory } from 'lib/router';
 import arrow from 'assets/icons/arrow_forward.svg';
 
 import { IMenu } from 'types/category';
+import { ESortType } from 'types/item';
 
 import { ITEM_LIST_URL } from 'constants/urls';
 
@@ -77,7 +78,7 @@ const Image = styled.img`
 const MediumMenu: FC<MediumMenuProps> = ({ menu, selectedLargeId, selectedMediumId, isMobile, setMediumId }) => {
   const history = useHistory();
   const goCategoryPage = useCallback(
-    (code: string) => () => history.push(`${ITEM_LIST_URL}?categoryId=${code}&pageId=1`),
+    (code: string) => () => history.push(`${ITEM_LIST_URL}?categoryId=${code}&pageId=1&type=${ESortType.RECOMMEND}`),
     [history],
   );
 
@@ -99,7 +100,7 @@ const MediumMenu: FC<MediumMenuProps> = ({ menu, selectedLargeId, selectedMedium
                     setMediumId(mediumId);
                     e.stopPropagation();
                   } else {
-                    history.push(`${ITEM_LIST_URL}?categoryId=${medium.code}&pageId=1`);
+                    history.push(`${ITEM_LIST_URL}?categoryId=${medium.code}&pageId=1&type=${ESortType.RECOMMEND}`);
                   }
                 }}
                 isSelected={selectedMediumId === mediumId}

--- a/client/src/containers/item-container.tsx
+++ b/client/src/containers/item-container.tsx
@@ -23,7 +23,7 @@ const ItemContainer: FC<ItemContainerProps> = ({ item }) => {
     userId: auth.user.userId,
   }));
 
-  const goDetailPage = useCallback((id: number) => () => history.push(`${ITEM_URL}/${id}`), [history]);
+  const goDetailPage = useCallback((id: number) => () => history.push(`${ITEM_URL}/${id}?pageId=1`), [history]);
 
   const toggleIsLiked = () => {
     if (!isLiked) {

--- a/client/src/containers/item-container.tsx
+++ b/client/src/containers/item-container.tsx
@@ -23,7 +23,7 @@ const ItemContainer: FC<ItemContainerProps> = ({ item }) => {
     userId: auth.user.userId,
   }));
 
-  const goDetailPage = useCallback((id: number) => () => history.push(`${ITEM_URL}/${id}?pageId=1`), [history]);
+  const goDetailPage = useCallback((id: number) => () => history.push(`${ITEM_URL}/${id}`), [history]);
 
   const toggleIsLiked = () => {
     if (!isLiked) {

--- a/client/src/containers/item-detail-container.tsx
+++ b/client/src/containers/item-detail-container.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useRef, useState } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
-import { useParams, useHistory } from 'lib/router';
+import { useParams, useHistory, useQuery } from 'lib/router';
 
 import { PAYMENT_URL } from 'constants/urls';
 
@@ -22,10 +22,10 @@ const ItemDetailContainer: FC = () => {
   const [file, setFile] = useState<null | File>(null);
   const [star, setStar] = useState(5);
   const [count, setCount] = useState(1);
-  const [pageId, setPageId] = useState(1);
   const [modalVisible, setModalVisible] = useState(false);
   const dispatch = useDispatch();
   const history = useHistory();
+  const query = useQuery();
   const { id } = useParams();
 
   const {
@@ -77,9 +77,10 @@ const ItemDetailContainer: FC = () => {
   }, [reviews]);
 
   useEffect(() => {
+    const { pageId } = query;
     dispatch({ type: getItem.type, payload: { id } });
     dispatch({ type: getReviews.type, payload: { itemId: id, pageId } });
-  }, [id, dispatch, pageId]);
+  }, [query, id, dispatch]);
 
   useEffect(() => {
     setIsLiked(isLike);
@@ -170,8 +171,6 @@ const ItemDetailContainer: FC = () => {
         itemLoading={itemLoading}
         reviewLoading={reviewLoading}
         pageCount={pageCount}
-        pageId={pageId}
-        setPageId={setPageId}
       />
       <ReviewPost
         userId={userId}

--- a/client/src/containers/my-order-list-container.tsx
+++ b/client/src/containers/my-order-list-container.tsx
@@ -83,7 +83,7 @@ const MyOrderListContainer: FC = () => {
         select={select}
       />
       <MyOrderTable loading={loading} orders={orders} totalCount={totalCount} />
-      <Pagination pageCount={pageCount} activePage={pageId} setActivePage={setPageId} />
+      <Pagination pageCount={pageCount} />
     </>
   );
 };

--- a/client/src/containers/my-order-list-container.tsx
+++ b/client/src/containers/my-order-list-container.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState, useEffect, useCallback } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'lib/router';
+import { useHistory, useQuery } from 'lib/router';
 
 import { RootState } from 'store';
 import { getOrders } from 'store/order';
@@ -17,8 +17,8 @@ const MyOrderListContainer: FC = () => {
   const [currentDate, setCurrentDate] = useState('');
   const [select, setSelect] = useState<undefined | number>(undefined);
   const history = useHistory();
+  const query = useQuery();
   const dispatch = useDispatch();
-  const [pageId, setPageId] = useState(1);
 
   const { loading, user, orders, pageCount, totalCount, userLoading } = useSelector(
     ({ auth, loading, order }: RootState) => ({
@@ -33,9 +33,10 @@ const MyOrderListContainer: FC = () => {
   );
 
   useEffect(() => {
+    const { pageId } = query;
     if (prevDate && currentDate)
       dispatch({ type: getOrders.type, payload: { pageId, prevDate, currentDate: getNextDay(currentDate) } });
-  }, [dispatch, pageId, prevDate, currentDate]);
+  }, [query, dispatch, prevDate, currentDate]);
 
   useEffect(() => {
     if (!userLoading && !user) history.push('/');

--- a/client/src/containers/search-container.tsx
+++ b/client/src/containers/search-container.tsx
@@ -57,7 +57,7 @@ const SearchContainer: FC = () => {
   const moveToSearchPage = (keyword: string) => {
     setSearch(keyword);
     saveRecentKeywords(keyword);
-    history.push(`${ITEM_LIST_URL}?search=${keyword}&pageId=1`);
+    history.push(`${ITEM_LIST_URL}?search=${keyword}`);
   };
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/client/src/containers/search-container.tsx
+++ b/client/src/containers/search-container.tsx
@@ -57,7 +57,7 @@ const SearchContainer: FC = () => {
   const moveToSearchPage = (keyword: string) => {
     setSearch(keyword);
     saveRecentKeywords(keyword);
-    history.push(`${ITEM_LIST_URL}?search=${keyword}`);
+    history.push(`${ITEM_LIST_URL}?search=${keyword}&pageId=1`);
   };
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/client/src/containers/search-item-container.tsx
+++ b/client/src/containers/search-item-container.tsx
@@ -1,8 +1,6 @@
-import React, { FC, useState, useEffect } from 'react';
+import React, { FC, useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useQuery } from 'lib/router';
-
-import { ESortType } from 'types/item';
 
 import SearchItemWrapper from 'components/item/search-item/search-item-wrapper';
 
@@ -11,7 +9,6 @@ import { getListItem } from 'store/item';
 
 const SearchItemContainer: FC = () => {
   const query = useQuery();
-  const [sortType, setSortType] = useState(ESortType.RECOMMEND);
   const dispatch = useDispatch();
 
   const { items, totalCount, pageCount, loading } = useSelector(
@@ -25,27 +22,14 @@ const SearchItemContainer: FC = () => {
   );
 
   useEffect(() => {
-    setSortType(ESortType.RECOMMEND);
-  }, [query]);
-
-  useEffect(() => {
-    const { categoryId, search, pageId } = query;
+    const { categoryId, search, pageId, type } = query;
     if ((categoryId || search) && pageId) {
-      dispatch({ type: getListItem.type, payload: { categoryId, pageId, type: sortType, search } });
+      dispatch({ type: getListItem.type, payload: { categoryId, pageId, type, search } });
       window.scrollTo(0, 0);
     }
-  }, [query, sortType, dispatch]);
+  }, [query, dispatch]);
 
-  return (
-    <SearchItemWrapper
-      items={items}
-      loading={loading}
-      pageCount={pageCount}
-      totalCount={totalCount}
-      sortType={sortType}
-      setSortType={setSortType}
-    />
-  );
+  return <SearchItemWrapper items={items} loading={loading} pageCount={pageCount} totalCount={totalCount} />;
 };
 
 export default SearchItemContainer;

--- a/client/src/containers/search-item-container.tsx
+++ b/client/src/containers/search-item-container.tsx
@@ -2,10 +2,12 @@ import React, { FC, useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useQuery } from 'lib/router';
 
-import SearchItemWrapper from 'components/item/search-item/search-item-wrapper';
+import { ESortType } from 'types/item';
 
 import { RootState } from 'store';
 import { getListItem } from 'store/item';
+
+import SearchItemWrapper from 'components/item/search-item/search-item-wrapper';
 
 const SearchItemContainer: FC = () => {
   const query = useQuery();
@@ -22,8 +24,8 @@ const SearchItemContainer: FC = () => {
   );
 
   useEffect(() => {
-    const { categoryId, search, pageId, type } = query;
-    if ((categoryId || search) && pageId) {
+    const { categoryId, search, pageId = 1, type = ESortType.RECOMMEND } = query;
+    if (categoryId || search) {
       dispatch({ type: getListItem.type, payload: { categoryId, pageId, type, search } });
       window.scrollTo(0, 0);
     }

--- a/client/src/containers/search-item-container.tsx
+++ b/client/src/containers/search-item-container.tsx
@@ -11,7 +11,6 @@ import { getListItem } from 'store/item';
 
 const SearchItemContainer: FC = () => {
   const query = useQuery();
-  const [pageId, setPageId] = useState(1);
   const [sortType, setSortType] = useState(ESortType.RECOMMEND);
   const dispatch = useDispatch();
 
@@ -30,24 +29,18 @@ const SearchItemContainer: FC = () => {
   }, [query]);
 
   useEffect(() => {
-    setPageId(1);
-  }, [query, sortType]);
-
-  useEffect(() => {
-    const { categoryId, search } = query;
+    const { categoryId, search, pageId } = query;
     if ((categoryId || search) && pageId) {
       dispatch({ type: getListItem.type, payload: { categoryId, pageId, type: sortType, search } });
       window.scrollTo(0, 0);
     }
-  }, [query, pageId, sortType, dispatch]);
+  }, [query, sortType, dispatch]);
 
   return (
     <SearchItemWrapper
       items={items}
       loading={loading}
       pageCount={pageCount}
-      pageId={pageId}
-      setPageId={setPageId}
       totalCount={totalCount}
       sortType={sortType}
       setSortType={setSortType}

--- a/client/src/lib/woowahan-components/components/woowahan-component.tsx
+++ b/client/src/lib/woowahan-components/components/woowahan-component.tsx
@@ -62,8 +62,8 @@ const woowahanComponent =
 
       Object.entries(props).forEach(([key, value]) => {
         if (typeof value === 'boolean') {
-          if (!reactProps.includes(key)) newProps[key.toLowerCase()] = value.toString();
-          else newProps[key] = value.toString();
+          if (!reactProps.includes(key)) newProps[key.toLowerCase()] = value ? 'true' : '';
+          else newProps[key] = value;
         } else if (!reactProps.includes(key)) {
           newProps[key.toLowerCase()] = value;
         } else {

--- a/client/src/lib/woowahan-components/configs/react-props.ts
+++ b/client/src/lib/woowahan-components/configs/react-props.ts
@@ -26,6 +26,7 @@ const reactProps = [
   'maxLength',
   'onSubmit',
   'htmlFor',
+  'selected',
 ];
 
 export default reactProps;

--- a/server/src/services/items.ts
+++ b/server/src/services/items.ts
@@ -80,6 +80,7 @@ async function getItems(
   else if (type === 'recent') order.push(['updatedAt', 'DESC']);
   else if (type === 'cheap') order.push(['price', 'ASC']);
   else if (type === 'expensive') order.push(['price', 'DESC']);
+  order.push(['id', 'ASC']);
 
   let data: IItemsData;
   if (categoryId) {

--- a/server/src/services/items.ts
+++ b/server/src/services/items.ts
@@ -80,7 +80,7 @@ async function getItems(
   else if (type === 'recent') order.push(['updatedAt', 'DESC']);
   else if (type === 'cheap') order.push(['price', 'ASC']);
   else if (type === 'expensive') order.push(['price', 'DESC']);
-  order.push(['id', 'ASC']);
+  order.push(['id', 'DESC']);
 
   let data: IItemsData;
   if (categoryId) {


### PR DESCRIPTION
<!--
======== Pull Request 자가 체크 리스트 ========
1. 작업 내용에 대해 lint 체크를 완료하였다.
2. 주석 및 불필요한 콘솔 로그를 지웠다.
3. 오타를 확인했다.
4. 버그가 없는지 충분히 테스트해보았다.
5. (프론트엔드) UI에서 기획과 다른 부분은 없는지 확인했다.
-->

## 개요 <!-- 필수 -->

페이지네이션 및 정렬을 url query 방식으로 변경하고 아이템 리스트를 가져올 때 중복 아이템 버그를 해결합니다.

## 이슈 번호 <!-- 필수 -->

- #185 
- #168 

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->

- 페이지네이션 컴포넌트 url query 적용
- filter 컴포넌트 url query 적용
- 아이템 정렬방식 order에 id 추가
- 주문목록 key 에러 해결
- 우아한 컴포넌트 버그 해결

## 스크린샷 <!-- 클라이언트 작업의 경우 필수 -->

![2021-08-30 17 13 44](https://user-images.githubusercontent.com/22045163/131308104-9aebf139-e52a-4ec6-9197-f071b222ce35.gif)
